### PR TITLE
Remove TestFlight tag-push auto-trigger (closes #392 mitigation step)

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -27,8 +27,22 @@ name: "TestFlight Submission"
 # ---------------------------------------------------------------------------
 # Trigger configuration
 # ---------------------------------------------------------------------------
-# Runs on manual dispatch or when beta/RC tags are pushed.
-# ---------------------------------------------------------------------------
+# Manual dispatch ONLY. The previous tag-push trigger has been intentionally
+# removed because TestFlight uploads must not happen automatically while the
+# App Store build (ITMS-90230/-90236/-90237/-90264/-90270/-90889) still
+# has open compliance work. This guard is BELT-AND-BRACES with
+# `gh workflow disable` at the registry level — both must be reversed
+# before automated TestFlight submissions resume.
+#
+# To re-enable automated submissions:
+#   1. Resolve every open ITMS-* issue tracked under the `app-store-compliance`
+#      label so a TestFlight upload won't be rejected by Apple's validators.
+#   2. Restore the tag-push trigger here (see the `# DISABLED:` block below).
+#   3. Run `gh workflow enable "TestFlight Submission"`.
+#
+# Until then, the workflow can still be triggered MANUALLY via
+# `gh workflow run "TestFlight Submission"` after `gh workflow enable …`,
+# which is an explicit two-step operator action.
 on:
   workflow_dispatch:
     inputs:
@@ -36,10 +50,14 @@ on:
         description: "TestFlight release notes"
         required: false
         default: "Bug fixes and improvements"
-  push:
-    tags:
-      - "v*-beta*"
-      - "v*-rc*"
+  # DISABLED: see header comment above. Restoring this block re-arms the
+  # tag-push auto-trigger that uploaded build 244 to App Store Connect
+  # before the App Store toolchain compliance work was done.
+  #
+  # push:
+  #   tags:
+  #     - "v*-beta*"
+  #     - "v*-rc*"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

Belt-and-braces lockout of automated TestFlight submissions until the App Store compliance work in #386–#391 is closed and explicit operator sign-off is given.

## Context

Tagging \`v0.1.0-rc.1\` today fired \`testflight.yml\` because its trigger matched \`v*-rc*\`, uploading build 244 to App Store Connect. Apple's validators returned seven ITMS-* compliance findings — all genuine, all requiring real work (toolchain change to \`productbuild\`/Xcode, new certificate types, embedded provisioning profile, ICNS-format icon, product-metadata fixes).

The project was only ever ready for direct (DMG) distribution. The App Store / TestFlight channel was infrastructure-in-waiting that should not have fired without an explicit operator action.

## Changes

- Drop the \`push.tags\` trigger from \`.github/workflows/testflight.yml\`. The previous block is preserved as a commented-out region with documented restoration steps.
- Only \`workflow_dispatch\` remains, so \`gh workflow run "TestFlight Submission"\` is now the sole automation entry point.

## Belt-and-braces

Already done at the registry level: \`gh workflow disable "TestFlight Submission"\`. Both this trigger change and the registry-level disable must be reversed for automated submissions to resume.

## Re-enable preconditions (see #392)

1. All of #386–#391 closed.
2. Successful manual TestFlight upload via \`gh workflow run\` with no ITMS-* findings.
3. Explicit project-owner sign-off.

## Test plan

- [x] Workflow YAML syntax valid (no breaking changes to job steps).
- [ ] After merge: verify no automated TestFlight runs trigger on future tag pushes by tagging a throwaway \`v0.0.0-rc.0\` (or just confirming the workflow run page shows no new entries when the next \`v*-rc*\` lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)