### PR TITLE
Fix extract-changelog.sh BSD-sed incompatibility (release.yml fix)

### DIFF
--- a/scripts/extract-changelog.sh
+++ b/scripts/extract-changelog.sh
@@ -75,7 +75,25 @@ SECTION=$(awk -v ver="$VERSION" '
 # ---------------------------------------------------------------------------
 # Strip leading/trailing blank lines from the extracted section
 # ---------------------------------------------------------------------------
-SECTION=$(echo "$SECTION" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba}')
+#
+# The leading-blank-strip via `sed '/./,$!d'` is POSIX-portable and works
+# under both BSD sed (macOS default) and GNU sed.
+#
+# The trailing-blank-strip used to be the GNU-sed idiom
+# `sed -e :a -e '/^\n*$/{$d;N;ba}'`, which fails on BSD sed with
+# "unexpected EOF (pending }'s)" — BSD sed parses brace groups differently
+# and won't accept the `$d;N;ba` semicolon-separated commands inside `{...}`.
+# release.yml runs on `macos-15`, so BSD sed is what we get.
+#
+# Replace it with portable awk: buffer all input, track the last non-blank
+# line index, and emit only up to that point.
+SECTION=$(echo "$SECTION" | sed '/./,$!d' | awk '
+    { lines[NR] = $0 }
+    /[^[:space:]]/ { last_content = NR }
+    END {
+        for (i = 1; i <= last_content; i++) print lines[i]
+    }
+')
 
 if [ -n "$SECTION" ]; then
     echo "$SECTION"


### PR DESCRIPTION
## Summary

\`release.yml\` made it through every signing and notarization step on \`v0.1.0-rc.2\` and then failed at the **\"Generate changelog\"** step:

\`\`\`
sed: 2: "/^\n*$/{\$d;N;ba}": unexpected EOF (pending }'s)
\`\`\`

The script's trailing-blank-strip used the GNU-sed idiom \`sed -e :a -e '/^\n*$/{$d;N;ba}'\`, which BSD sed (the default on \`macos-15\` runners) cannot parse — it handles brace groups differently.

## Fix

Replace the broken sed with portable awk that buffers all lines, tracks the last non-blank line's index, and emits only up to that point. Blank lines in the middle of the section are preserved. The leading-blank-strip via \`sed '/./,$!d'\` is already POSIX-portable and stays.

## Test plan

- [x] Local \`./scripts/extract-changelog.sh 0.1.0\` runs clean (falls through to git-log fallback because the section is still under \`[Unreleased]\` — expected).
- [x] Local \`./scripts/extract-changelog.sh 0.1.0-rc.2\` runs clean and emits the expected commit-list fallback.
- [ ] After merge: re-tag \`v0.1.0-rc.3\` and watch \`release.yml\` produce the GitHub Release with attached DMG.

## Notes

- Everything before this step succeeded on v0.1.0-rc.2: build, release-mode tests (Keychain tests now skip gracefully), app-bundle signing, notarization, DMG creation, DMG signing+notarization, CLI binary signing+packaging. So once this lands, the next tag should reach \"Create GitHub Release\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)