### PR TITLE
Add Metadata settings tab with SuiteCoreMetadataBackend picker (part of #381, addresses #398)

### DIFF
--- a/Sources/MeedyaConverter/Views/SettingsView.swift
+++ b/Sources/MeedyaConverter/Views/SettingsView.swift
@@ -67,6 +67,10 @@ struct SettingsView: View {
                     PathSettingsTab()
                 }
 
+                Tab("Metadata", systemImage: "tag") {
+                    MetadataSettingsTab()
+                }
+
                 Tab("Watch Folder", systemImage: "eye") {
                     WatchFolderView()
                 }
@@ -196,6 +200,139 @@ struct EncodingSettingsTab: View {
         }
         .formStyle(.grouped)
         .navigationTitle("Encoding")
+    }
+}
+
+// MARK: - MetadataSettingsTab (Issues #371 engine / #381 / #398 UI)
+//
+// Lets the user pick which backend strategy MeedyaConverter uses for metadata
+// lookups (cover art, episode info, IDs, etc.). Three options:
+//
+//   * Automatic — Prefer MeedyaSuite-core when linked; fall back to the
+//                 built-in inline providers otherwise. This is the safest
+//                 default and what existing users get with no action.
+//   * Suite-core — Force suite-core. Throws `.notCompiledIn` at lookup time
+//                  if the binary wasn't built with `SUITE_CORE=1`, which is
+//                  why this option is *disabled* in the picker when
+//                  `SuiteCoreAvailability.isAvailable` is false.
+//   * Inline only — Bypass suite-core even when it is linked in. Useful
+//                   when debugging provider parity between the two backends.
+//
+// Persistence: a single `@AppStorage` key (`metadataBackend`) holding the
+// enum's rawValue. Engine consumers construct a `SuiteCoreMetadataAdapter`
+// from that key (read via `UserDefaults.standard` in the engine layer, or
+// passed through from the view-model — both work).
+
+/// Metadata-backend selection settings.
+struct MetadataSettingsTab: View {
+
+    /// Persisted backend choice. Default is `automatic` so existing
+    /// installs (no key written) behave exactly as before.
+    @AppStorage("metadataBackend") private var rawBackend: String =
+        SuiteCoreMetadataBackend.automatic.rawValue
+
+    /// Bridged `SuiteCoreMetadataBackend` binding. Parses the persisted
+    /// rawValue on read; if a corrupt value sneaks into UserDefaults (e.g.
+    /// from a future build that adds a case this binary doesn't know),
+    /// we silently fall back to `.automatic` so the UI never crashes.
+    private var backend: Binding<SuiteCoreMetadataBackend> {
+        Binding<SuiteCoreMetadataBackend>(
+            get: {
+                SuiteCoreMetadataBackend(rawValue: rawBackend) ?? .automatic
+            },
+            set: { rawBackend = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        Form {
+            Section("Provider backend") {
+                Picker("Strategy", selection: backend) {
+                    ForEach(SuiteCoreMetadataBackend.allCases, id: \.self) { option in
+                        // Disable `.suiteCore` when the binary wasn't built
+                        // with SUITE_CORE=1; otherwise picking it would mean
+                        // every lookup throws `.notCompiledIn`.
+                        let isOptionDisabled =
+                            option == .suiteCore
+                            && !SuiteCoreAvailability.isAvailable
+                        Text(displayName(for: option))
+                            .tag(option)
+                            .foregroundStyle(isOptionDisabled ? .secondary : .primary)
+                    }
+                }
+                .pickerStyle(.inline)
+                .accessibilityLabel("Metadata provider backend strategy")
+
+                // Help text — matches the copy specified in #381 verbatim
+                // so a future audit can grep for it.
+                Text(
+                    "Automatic uses MeedyaSuite-core when linked, "
+                    + "else the built-in providers."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                // Live status line. Surfaces what's actually going to happen
+                // right now, which is more useful than just describing the
+                // options abstractly — especially when `.automatic` is the
+                // default and the user might not realise suite-core isn't
+                // available in this build.
+                statusLine
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Metadata")
+    }
+
+    // MARK: - Helpers
+
+    /// User-facing label for each `SuiteCoreMetadataBackend` case. Kept
+    /// in this file (rather than as a property on the engine enum) because
+    /// it is purely a UI string and shouldn't pollute the engine's public
+    /// API surface.
+    private func displayName(for backend: SuiteCoreMetadataBackend) -> String {
+        switch backend {
+        case .automatic:  return "Automatic (recommended)"
+        case .suiteCore:
+            return SuiteCoreAvailability.isAvailable
+                ? "MeedyaSuite-core only"
+                : "MeedyaSuite-core only (unavailable — rebuild with SUITE_CORE=1)"
+        case .inlineOnly: return "Built-in providers only"
+        }
+    }
+
+    /// One-line summary of which backend will service the next lookup,
+    /// given the current selection AND the runtime suite-core availability.
+    @ViewBuilder
+    private var statusLine: some View {
+        let selected = SuiteCoreMetadataBackend(rawValue: rawBackend) ?? .automatic
+        let suiteCoreLinked = SuiteCoreAvailability.isAvailable
+
+        switch selected {
+        case .automatic:
+            if suiteCoreLinked {
+                Text("Currently routing through MeedyaSuite-core "
+                     + "(version \(SuiteCoreAvailability.linkedVersion ?? "unknown")).")
+            } else {
+                Text("MeedyaSuite-core is not linked in this build — "
+                     + "using the built-in providers.")
+            }
+        case .suiteCore:
+            if suiteCoreLinked {
+                Text("Forcing MeedyaSuite-core. Lookups for sources without "
+                     + "a suite-core mapping will throw.")
+            } else {
+                Text("MeedyaSuite-core is not available; this option will "
+                     + "throw at lookup time. Switch to Automatic or "
+                     + "Built-in providers.")
+                    .foregroundStyle(.orange)
+            }
+        case .inlineOnly:
+            Text("Bypassing MeedyaSuite-core. Using the built-in providers "
+                 + "even when suite-core is linked.")
+        }
     }
 }
 

--- a/Tests/ConverterEngineTests/ConverterEngineTests.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests.swift
@@ -10532,6 +10532,40 @@ final class ConverterEngineTests: XCTestCase {
         }
     }
 
+    // MARK: - SuiteCoreMetadataBackend (#371 / #381 / #398)
+
+    /// `SuiteCoreMetadataBackend` is persisted as its rawValue String via
+    /// `@AppStorage("metadataBackend")` in the SettingsView. Pin the three
+    /// expected rawValues so a rename in the engine doesn't silently
+    /// invalidate every user's persisted preference at next launch.
+    func test_suiteCoreMetadataBackend_rawValuesAreStableForAppStorage() {
+        XCTAssertEqual(SuiteCoreMetadataBackend.automatic.rawValue, "automatic")
+        XCTAssertEqual(SuiteCoreMetadataBackend.suiteCore.rawValue, "suiteCore")
+        XCTAssertEqual(SuiteCoreMetadataBackend.inlineOnly.rawValue, "inlineOnly")
+    }
+
+    /// Verifies that all three cases round-trip through their rawValue,
+    /// which is what the UI's AppStorage binding relies on. If a future
+    /// case is added without a stable rawValue, this test catches it.
+    func test_suiteCoreMetadataBackend_allCasesRoundTripThroughRawValue() {
+        for backend in SuiteCoreMetadataBackend.allCases {
+            let raw = backend.rawValue
+            let recovered = SuiteCoreMetadataBackend(rawValue: raw)
+            XCTAssertEqual(recovered, backend,
+                           "Backend \(backend) does not round-trip via "
+                           + "rawValue '\(raw)'")
+        }
+    }
+
+    /// The UI falls back to `.automatic` when AppStorage contains an
+    /// unrecognised rawValue (e.g. a value written by a future build that
+    /// added a case this one doesn't know). Verify the parsing behaviour
+    /// this fallback depends on.
+    func test_suiteCoreMetadataBackend_unknownRawValueReturnsNil() {
+        XCTAssertNil(SuiteCoreMetadataBackend(rawValue: "futureBackendName"))
+        XCTAssertNil(SuiteCoreMetadataBackend(rawValue: ""))
+    }
+
     // MARK: - SubtitleTonemapWrapper (#369)
 
     /// Pins the SubtitleTonemapConfig default-initialised values against


### PR DESCRIPTION
## Summary

Second sub-task of the [#381](../issues/381) UI gap (after [#397](../pull/397) for SubtitleTonemap). Surfaces the metadata-backend strategy that landed for [#371](../issues/371) in the SwiftUI layer. Tracking: [#398](../issues/398).

## Changes

### UI

New \`MetadataSettingsTab\` in [SettingsView.swift](Sources/MeedyaConverter/Views/SettingsView.swift), slotted into the existing \`Encoding\` \`TabSection\` between Paths and Watch Folder (icon: \`tag\`).

| Element | Bound to | Notes |
|---------|----------|-------|
| Picker — Strategy | \`@AppStorage("metadataBackend")\` (String rawValue) | \`SuiteCoreMetadataBackend.allCases\` |
| Help text | static | "Automatic uses MeedyaSuite-core when linked, else the built-in providers." (verbatim from #381) |
| Status line | live, derived from selection × runtime availability | "Currently routing through MeedyaSuite-core (version X.Y.Z)" or "MeedyaSuite-core is not linked in this build — using the built-in providers." |
| Disabled case | \`.suiteCore\` when \`SuiteCoreAvailability.isAvailable == false\` | rendered with \`.secondary\` foreground + "(unavailable — rebuild with SUITE_CORE=1)" suffix |

If \`UserDefaults\` somehow holds an unknown rawValue (e.g. from a future build that adds a case this binary doesn't know), the binding silently falls back to \`.automatic\`.

### Tests

- \`test_suiteCoreMetadataBackend_rawValuesAreStableForAppStorage\` — pins the three rawValues so an engine-side rename doesn't silently invalidate every user's persisted preference.
- \`test_suiteCoreMetadataBackend_allCasesRoundTripThroughRawValue\` — every case parses back from its rawValue.
- \`test_suiteCoreMetadataBackend_unknownRawValueReturnsNil\` — protects the UI's corrupt-rawValue fallback.

### Out of scope

Adapter call-site wiring. This PR only adds the UI surface + persistence. Engine-side consumers that want to honour the user's choice can read the AppStorage key in a follow-up.

## Test plan

- [x] \`swift build\` clean, no warnings.
- [x] \`swift test --filter test_suiteCoreMetadataBackend\` — 3 new tests pass.
- [ ] After merge: open Settings → Metadata, switch the picker, restart, verify the choice persists.

## #381 progress

- [x] #1 SubtitleTonemap → \`OutputSettingsView\` (PR #397 merged)
- [x] #5 SuiteCoreMetadataBackend → new Metadata tab (this PR)
- [ ] #6 AccurateRip submission → new tab
- [ ] #2 RasterToVectorConfig → new VectorConversionView
- [ ] #3 ProResToVectorConfig → new ProResVectorView
- [ ] #4 RenderFarmClient.Configuration → new Render Farm tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)