### PR TITLE
Add Audio CD settings tab for AccurateRip submission (part of #381, addresses #400)

### DIFF
--- a/Sources/MeedyaConverter/Views/SettingsView.swift
+++ b/Sources/MeedyaConverter/Views/SettingsView.swift
@@ -71,6 +71,10 @@ struct SettingsView: View {
                     MetadataSettingsTab()
                 }
 
+                Tab("Audio CD", systemImage: "opticaldisc") {
+                    AccurateRipSettingsTab()
+                }
+
                 Tab("Watch Folder", systemImage: "eye") {
                     WatchFolderView()
                 }
@@ -333,6 +337,127 @@ struct MetadataSettingsTab: View {
             Text("Bypassing MeedyaSuite-core. Using the built-in providers "
                  + "even when suite-core is linked.")
         }
+    }
+}
+
+// MARK: - AccurateRipSettingsTab (#381 / #400)
+//
+// Exposes the user-facing settings for AccurateRip submission. AccurateRip
+// is a community database that lets CD rippers verify their rips against
+// thousands of other users' rips of the same disc — a near-certain way to
+// catch read errors, jitter, or offset issues that defeat checksum-only
+// verification. Submitting our own verified rips back to the database
+// keeps the community dataset growing.
+//
+// The submission API is in `AccurateRipVerifier.SubmissionConfig`:
+//
+//   enabled:     Bool   - master opt-in (default false; submission is opt-in
+//                         per AccurateRip's terms)
+//   driveModel:  String - exact drive model string (used by AccurateRip
+//                         to bucket results by drive)
+//   driveOffset: Int    - per-drive read offset in samples; without this
+//                         the rip can be bit-perfect but offset from the
+//                         reference, producing a non-match
+//   softwareId:  String - identifies the ripping software (default
+//                         "MeedyaConverter"; AccurateRip uses this in
+//                         user-agent strings and statistics)
+//
+// Persistence: four `@AppStorage` keys mirroring the struct fields.
+// Engine consumers (the rip pipeline) read the keys and assemble a
+// `SubmissionConfig` at submission time. Keeping persistence keyed
+// per-field rather than as a JSON-encoded blob means a future addition
+// to `SubmissionConfig` doesn't invalidate the user's existing settings.
+
+/// AccurateRip submission preferences.
+struct AccurateRipSettingsTab: View {
+
+    /// Master opt-in. AccurateRip submission is off by default; users
+    /// must consciously opt in (matching the engine's
+    /// `SubmissionConfig.init` default of `false`).
+    @AppStorage("accurateRip.enabled") private var enabled: Bool = false
+
+    /// Drive model string. Persisted as-typed; we don't try to validate
+    /// against a known-drives list because the AccurateRip table is
+    /// large and updated separately from the app.
+    @AppStorage("accurateRip.driveModel") private var driveModel: String = ""
+
+    /// Drive read offset in samples. The acceptance criteria pin the
+    /// range to ±500; in practice most drives are within ±200, but
+    /// some outliers do exist on the AccurateRip drive-offset table.
+    @AppStorage("accurateRip.driveOffset") private var driveOffset: Int = 0
+
+    /// Software identifier sent with submissions. Defaulted to
+    /// "MeedyaConverter" to match the engine's `SubmissionConfig` default
+    /// — pinned via a test in `ConverterEngineTests`.
+    @AppStorage("accurateRip.softwareId") private var softwareId: String = "MeedyaConverter"
+
+    var body: some View {
+        Form {
+            Section("AccurateRip") {
+                // Master toggle. Gates the rest of the form.
+                Toggle(
+                    "Submit verified rips to AccurateRip database",
+                    isOn: $enabled
+                )
+                .accessibilityLabel(
+                    "Enable submission of verified Audio CD rips to the "
+                    + "AccurateRip database"
+                )
+                .help(
+                    "When enabled, MeedyaConverter contributes successfully-"
+                    + "verified rips back to the AccurateRip community "
+                    + "database. Disabled by default; opt-in only."
+                )
+
+                // Subordinate fields. We render them at full visibility
+                // regardless of the master toggle but `.disabled` them
+                // when it's off — that way users can see what the
+                // controls look like before opting in, and don't accidentally
+                // type credentials into a non-functional field.
+                TextField(
+                    "Drive model",
+                    text: $driveModel,
+                    prompt: Text("e.g. PIONEER BD-RW BDR-XS07")
+                )
+                .accessibilityLabel("Optical drive model name")
+                .disabled(!enabled)
+
+                Stepper(
+                    value: $driveOffset,
+                    in: -500...500,
+                    step: 1
+                ) {
+                    HStack {
+                        Text("Read offset")
+                        Spacer()
+                        Text("\(driveOffset > 0 ? "+" : "")\(driveOffset) samples")
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                .accessibilityLabel("Drive read offset in samples")
+                .disabled(!enabled)
+
+                TextField(
+                    "Software identifier",
+                    text: $softwareId,
+                    prompt: Text("MeedyaConverter")
+                )
+                .accessibilityLabel("Software identifier sent with submissions")
+                .disabled(!enabled)
+
+                // Help line linking to the AccurateRip drive-offset table.
+                // Mandated by the #381 spec — users without their drive
+                // offset would otherwise submit non-matching rips.
+                Link(
+                    "Find your drive's read offset on accuraterip.com",
+                    destination: URL(string: "https://www.accuraterip.com/driveoffsets.htm")!
+                )
+                .font(.caption)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Audio CD")
     }
 }
 

--- a/Tests/ConverterEngineTests/ConverterEngineTests.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests.swift
@@ -10532,6 +10532,49 @@ final class ConverterEngineTests: XCTestCase {
         }
     }
 
+    // MARK: - AccurateRip SubmissionConfig (#381 / #400)
+
+    /// Pins the `AccurateRipVerifier.SubmissionConfig` default-initialised
+    /// values against the AppStorage defaults baked into
+    /// `AccurateRipSettingsTab`. The UI assumes that constructing a
+    /// `SubmissionConfig()` with no arguments produces the same values
+    /// the AppStorage keys default to — drift between the two would mean
+    /// a user who has never opened the settings tab gets a config that
+    /// silently differs from what an engine consumer using the type's
+    /// default-init would produce.
+    func test_accurateRipSubmissionConfig_defaultsMatchUIAppStorage() {
+        let defaults = AccurateRipVerifier.SubmissionConfig()
+        XCTAssertFalse(defaults.enabled,
+                       "UI master toggle defaults to off — opt-in only")
+        XCTAssertEqual(defaults.driveModel, "",
+                       "UI driveModel TextField defaults to empty")
+        XCTAssertEqual(defaults.driveOffset, 0,
+                       "UI driveOffset Stepper defaults to 0")
+        XCTAssertEqual(defaults.softwareId, "MeedyaConverter",
+                       "UI softwareId TextField defaults to 'MeedyaConverter'")
+    }
+
+    /// Verifies the SubmissionConfig round-trips through JSON. The four
+    /// AppStorage keys persist the individual fields separately, but a
+    /// future migration that stores the assembled struct as a single
+    /// JSON blob (or pushes it to a remote profile sync) needs this to
+    /// keep working. Pin it now.
+    func test_accurateRipSubmissionConfig_codableRoundTrip() throws {
+        let original = AccurateRipVerifier.SubmissionConfig(
+            enabled: true,
+            driveModel: "PIONEER BD-RW BDR-XS07",
+            driveOffset: 102,
+            softwareId: "MeedyaConverter"
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder()
+            .decode(AccurateRipVerifier.SubmissionConfig.self, from: data)
+        XCTAssertEqual(decoded.enabled, true)
+        XCTAssertEqual(decoded.driveModel, "PIONEER BD-RW BDR-XS07")
+        XCTAssertEqual(decoded.driveOffset, 102)
+        XCTAssertEqual(decoded.softwareId, "MeedyaConverter")
+    }
+
     // MARK: - SuiteCoreMetadataBackend (#371 / #381 / #398)
 
     /// `SuiteCoreMetadataBackend` is persisted as its rawValue String via


### PR DESCRIPTION
## Summary

Third sub-task of the [#381](../issues/381) UI gap — **completes the priority-1 set**. Lands the user-facing surface for \`AccurateRipVerifier.SubmissionConfig\` so users can opt in (and configure their drive) without editing defaults files. Tracking: [#400](../issues/400).

## Changes

### UI

New \`AccurateRipSettingsTab\` in [SettingsView.swift](Sources/MeedyaConverter/Views/SettingsView.swift), slotted into the existing \`Encoding\` \`TabSection\` between Metadata and Watch Folder (icon: \`opticaldisc\`, label: "Audio CD").

| Control | AppStorage key | Default | Notes |
|---------|---------------|---------|-------|
| Toggle — "Submit verified rips to AccurateRip database" | \`accurateRip.enabled\` | \`false\` | opt-in only |
| TextField — Drive model | \`accurateRip.driveModel\` | \`""\` | prompt: "e.g. PIONEER BD-RW BDR-XS07" |
| Stepper — Read offset | \`accurateRip.driveOffset\` | \`0\` | range -500…+500, step 1, monospaced sample count with explicit sign |
| TextField — Software identifier | \`accurateRip.softwareId\` | \`"MeedyaConverter"\` | prompt: "MeedyaConverter" |
| Link — drive-offset table | — | — | https://www.accuraterip.com/driveoffsets.htm |

Subordinate fields are \`.disabled\` when the master toggle is off — users see the form structure before opting in but can't accidentally type credentials into a non-functional field.

### Tests

- \`test_accurateRipSubmissionConfig_defaultsMatchUIAppStorage\` — pins the four UI defaults against the engine's \`SubmissionConfig\` default-init. Drift between UI and engine defaults would mean a user who never opens the tab gets a different config than an engine caller using \`SubmissionConfig()\`.
- \`test_accurateRipSubmissionConfig_codableRoundTrip\` — verifies the assembled struct survives JSON encode/decode.

## #381 progress

- [x] **#1 SubtitleTonemap** → \`OutputSettingsView\` ([PR #397](../pull/397) merged)
- [x] **#5 SuiteCoreMetadataBackend** → new Metadata tab ([PR #399](../pull/399) merged)
- [x] **#6 AccurateRip submission** → new Audio CD tab (this PR)
- [ ] **#2 RasterToVectorConfig** → new \`VectorConversionView\` (priority-2, larger surface)
- [ ] **#3 ProResToVectorConfig** → new \`ProResVectorView\` (priority-2, larger surface)
- [ ] **#4 RenderFarmClient.Configuration** → new Render Farm tab (priority-3, depends on #346 transport)

## Test plan

- [x] \`swift build\` clean, no warnings.
- [x] \`swift test --filter test_accurateRipSubmissionConfig\` — 2 new tests pass.
- [ ] After merge: open Settings → Audio CD, toggle on, fill drive model, restart, verify settings persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)