### PR TITLE
Add VectorConversionView under Tools menu (part of #381, addresses #402)

### DIFF
--- a/Sources/MeedyaConverter/ViewModels/AppViewModel.swift
+++ b/Sources/MeedyaConverter/ViewModels/AppViewModel.swift
@@ -48,6 +48,9 @@ enum NavigationItem: String, CaseIterable, Identifiable {
     /// Image conversion — batch image format conversion.
     case images = "Images"
 
+    /// Raster → vector (SVG) conversion. Issues #376 engine / #381 / #402 UI.
+    case vectorConversion = "Vector Conversion"
+
     /// Disc burning — write to physical optical media.
     case burn = "Burn"
 
@@ -136,6 +139,7 @@ enum NavigationItem: String, CaseIterable, Identifiable {
         case .dashboard:         return "chart.bar.xaxis"
         case .resourceMonitor:   return "gauge.with.dots.needle.33percent"
         case .images:            return "photo.on.rectangle.angled"
+        case .vectorConversion:  return "scribble.variable"
         case .burn:              return "opticaldisc"
         case .trimEdit:          return "scissors"
         case .analyze:           return "waveform.and.magnifyingglass"
@@ -174,6 +178,7 @@ enum NavigationItem: String, CaseIterable, Identifiable {
         case .dashboard:         return "View encoding statistics dashboard"
         case .resourceMonitor:   return "Monitor system resources"
         case .images:            return "Convert images"
+        case .vectorConversion:  return "Convert raster images to vector SVG"
         case .burn:              return "Burn disc"
         case .trimEdit:          return "Trim and edit video"
         case .analyze:           return "Analyse media files"

--- a/Sources/MeedyaConverter/Views/ContentView.swift
+++ b/Sources/MeedyaConverter/Views/ContentView.swift
@@ -98,6 +98,8 @@ struct ContentView: View {
         // -- Tools ---------------------------------------------------------
         case .images:
             ImageConversionView()
+        case .vectorConversion:
+            VectorConversionView()
         case .burn:
             BurnSettingsView()
         case .trimEdit:

--- a/Sources/MeedyaConverter/Views/VectorConversionView.swift
+++ b/Sources/MeedyaConverter/Views/VectorConversionView.swift
@@ -1,0 +1,345 @@
+// ============================================================================
+// MeedyaConverter — VectorConversionView
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+//
+// SwiftUI surface for raster→vector (SVG) conversion. Binds the eight
+// user-facing fields of `RasterToVectorConfig` from `ConverterEngine` and
+// persists the user's preferences via `@AppStorage`.
+//
+// Layout:
+//   1. Input    — Raster format picker (the only purely informational
+//                 control: the actual format is detected from the file).
+//   2. Preset   — Editability preset picker. Changing this auto-drives
+//                 the tracing mode and colour count to the preset's
+//                 recommended defaults, so users who pick a preset don't
+//                 need to fiddle with the lower-level controls.
+//   3. Tracing  — Tracing mode picker + colour count stepper. Colour
+//                 count is disabled when the tracing mode doesn't use it
+//                 (outline / monochrome — those produce a fixed number
+//                 of regions).
+//   4. Alpha    — Alpha strategy picker.
+//   5. Animation — Animation method picker, hidden unless the chosen
+//                  input format is animated (GIF / APNG / animated WebP).
+//   6. Extras   — Preserve metadata toggle, OCR toggle, curve
+//                 simplification stepper.
+//
+// GitHub Issues: #376 engine (RasterVectorConverter) / #381 / #402 UI.
+// ============================================================================
+
+import SwiftUI
+import ConverterEngine
+
+// MARK: - VectorConversionView
+
+/// User-facing settings for raster→vector (SVG) conversion.
+struct VectorConversionView: View {
+
+    // -----------------------------------------------------------------
+    // MARK: - Persisted state
+    // -----------------------------------------------------------------
+    //
+    // One AppStorage key per RasterToVectorConfig field. Per-field keys
+    // (rather than a JSON-encoded blob) mean a future addition to the
+    // engine config does not invalidate the user's existing preferences.
+    // The keys are namespaced under `vectorConversion.` so they are easy
+    // to grep for and to clear in tests.
+
+    /// Raster input format. Defaulted to PNG — the most common case —
+    /// so the form has a stable initial state.
+    @AppStorage("vectorConversion.inputFormat") private var rawInputFormat: String =
+        RasterFormat.png.rawValue
+
+    /// Editability preset. Changing this auto-drives `rawTracingMode`
+    /// and `colorCount` (see `applyPreset(_:)`).
+    @AppStorage("vectorConversion.preset") private var rawPreset: String =
+        EditabilityPreset.illustration.rawValue
+
+    /// Tracing mode. Initialised to the default for `illustration` so
+    /// the AppStorage default agrees with the engine's RasterToVectorConfig
+    /// default-init (pinned by a test in ConverterEngineTests).
+    @AppStorage("vectorConversion.tracingMode") private var rawTracingMode: String =
+        TracingMode.colorQuantization.rawValue
+
+    /// Quantisation colour count.
+    @AppStorage("vectorConversion.colorCount") private var colorCount: Int = 32
+
+    /// Alpha-channel handling strategy.
+    @AppStorage("vectorConversion.alpha") private var rawAlpha: String =
+        AlphaStrategy.clipPathWithOpacity.rawValue
+
+    /// Animation method used when the input is an animated raster.
+    @AppStorage("vectorConversion.animation") private var rawAnimation: String =
+        AnimationMethod.smil.rawValue
+
+    /// Whether to copy EXIF / IPTC / XMP into the SVG `<metadata>` block.
+    @AppStorage("vectorConversion.preserveMetadata") private var preserveMetadata: Bool = true
+
+    /// Whether to run OCR against detected text regions and emit them
+    /// as `<text>` elements instead of traced paths.
+    @AppStorage("vectorConversion.ocrTextRegions") private var ocrTextRegions: Bool = false
+
+    /// Curve-simplification tolerance. 0.0 = preserve every traced
+    /// point; 10.0 = very aggressive smoothing.
+    @AppStorage("vectorConversion.curveSimplification") private var curveSimplification: Double = 2.0
+
+    // -----------------------------------------------------------------
+    // MARK: - Computed bindings
+    // -----------------------------------------------------------------
+    //
+    // Bridge between the raw-String AppStorage values and the
+    // strongly-typed enums consumers actually want to manipulate. Each
+    // binding falls back to the engine's default when the persisted
+    // raw value is unrecognised (e.g. a future build added a case this
+    // binary doesn't know).
+
+    private var inputFormat: Binding<RasterFormat> {
+        Binding(
+            get: { RasterFormat(rawValue: rawInputFormat) ?? .png },
+            set: { rawInputFormat = $0.rawValue }
+        )
+    }
+
+    private var preset: Binding<EditabilityPreset> {
+        Binding(
+            get: { EditabilityPreset(rawValue: rawPreset) ?? .illustration },
+            set: { newPreset in
+                rawPreset = newPreset.rawValue
+                applyPreset(newPreset)
+            }
+        )
+    }
+
+    private var tracingMode: Binding<TracingMode> {
+        Binding(
+            get: { TracingMode(rawValue: rawTracingMode) ?? .colorQuantization },
+            set: { rawTracingMode = $0.rawValue }
+        )
+    }
+
+    private var alpha: Binding<AlphaStrategy> {
+        Binding(
+            get: { AlphaStrategy(rawValue: rawAlpha) ?? .clipPathWithOpacity },
+            set: { rawAlpha = $0.rawValue }
+        )
+    }
+
+    private var animation: Binding<AnimationMethod> {
+        Binding(
+            get: { AnimationMethod(rawValue: rawAnimation) ?? .smil },
+            set: { rawAnimation = $0.rawValue }
+        )
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Body
+    // -----------------------------------------------------------------
+
+    var body: some View {
+        Form {
+            Section("Input") {
+                Picker("Raster format", selection: inputFormat) {
+                    ForEach(RasterFormat.allCases, id: \.self) { format in
+                        Text(format.displayLabel).tag(format)
+                    }
+                }
+                .accessibilityLabel("Input raster format")
+            }
+
+            Section("Preset") {
+                Picker("Editability preset", selection: preset) {
+                    ForEach(EditabilityPreset.allCases, id: \.self) { p in
+                        Text(p.displayLabel).tag(p)
+                    }
+                }
+                .accessibilityLabel("Editability preset for the traced SVG")
+
+                Text(
+                    "Picking a preset auto-fills tracing mode and colour "
+                    + "count. Choose Custom to keep your manual values."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            Section("Tracing") {
+                Picker("Mode", selection: tracingMode) {
+                    ForEach(TracingMode.allCases, id: \.self) { mode in
+                        Text(mode.displayLabel).tag(mode)
+                    }
+                }
+                .accessibilityLabel("Tracing algorithm")
+
+                // Colour count only applies to colour-quantisation tracing
+                // (and to photorealistic mode, which is a higher-cost
+                // variant). Disable it for outline and monochrome so
+                // users don't waste time tweaking a value that has no
+                // effect on the output.
+                Stepper(
+                    value: $colorCount,
+                    in: 2...256,
+                    step: 1
+                ) {
+                    HStack {
+                        Text("Colour count")
+                        Spacer()
+                        Text("\(colorCount)")
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                .accessibilityLabel("Number of colours for quantisation tracing")
+                .disabled(!colorCountApplies(to: tracingMode.wrappedValue))
+            }
+
+            Section("Alpha") {
+                Picker("Strategy", selection: alpha) {
+                    ForEach(AlphaStrategy.allCases, id: \.self) { strategy in
+                        Text(strategy.displayLabel).tag(strategy)
+                    }
+                }
+                .pickerStyle(.inline)
+                .accessibilityLabel("Alpha-channel handling strategy")
+            }
+
+            // Animation picker is meaningless for static inputs. Render
+            // it only when the chosen input format is animated.
+            if inputFormat.wrappedValue.isAnimated {
+                Section("Animation") {
+                    Picker("Method", selection: animation) {
+                        ForEach(AnimationMethod.allCases, id: \.self) { method in
+                            Text(method.displayLabel).tag(method)
+                        }
+                    }
+                    .accessibilityLabel("Animation method for animated input")
+                }
+            }
+
+            Section("Other") {
+                Toggle("Preserve EXIF / IPTC / XMP metadata", isOn: $preserveMetadata)
+                    .accessibilityLabel(
+                        "Copy source metadata into the SVG metadata block"
+                    )
+
+                Toggle("OCR text regions", isOn: $ocrTextRegions)
+                    .accessibilityLabel(
+                        "Detect text regions and emit them as SVG text "
+                        + "elements instead of traced paths"
+                    )
+
+                Stepper(
+                    value: $curveSimplification,
+                    in: 0.0...10.0,
+                    step: 0.5
+                ) {
+                    HStack {
+                        Text("Curve simplification")
+                        Spacer()
+                        Text(String(format: "%.1f", curveSimplification))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                .accessibilityLabel(
+                    "Curve-simplification tolerance; 0 preserves every "
+                    + "point, 10 smooths aggressively"
+                )
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Vector Conversion")
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Preset auto-drive
+    // -----------------------------------------------------------------
+
+    /// When a preset is selected, push its recommended tracing mode and
+    /// colour count into the corresponding AppStorage keys so the lower
+    /// controls reflect the preset's intent. We deliberately do NOT
+    /// auto-drive when the preset is `.custom` — that case exists so
+    /// the user can keep their hand-tuned values without losing them
+    /// every time they revisit this view.
+    private func applyPreset(_ newPreset: EditabilityPreset) {
+        guard newPreset != .custom else { return }
+        rawTracingMode = newPreset.defaultTracingMode.rawValue
+        colorCount = newPreset.defaultColorCount
+    }
+
+    /// Whether the colour-count stepper has any effect under the given
+    /// tracing mode. Outline and monochrome ignore colour count by
+    /// construction; colour-quantisation and photorealistic respect it.
+    private func colorCountApplies(to mode: TracingMode) -> Bool {
+        switch mode {
+        case .outline, .monochrome:           return false
+        case .colorQuantization, .photorealistic: return true
+        }
+    }
+}
+
+// MARK: - Display-name helpers
+//
+// User-facing labels for the engine enums. Kept here rather than as
+// `displayName` properties on the engine types because they are purely
+// UI strings — making them part of the engine's public API would force
+// us to keep them in lockstep with translations and SwiftUI conventions.
+
+private extension RasterFormat {
+    /// User-facing label. RasterFormat covers ~30 cases (common web
+    /// formats plus raw camera formats like CR2/NEF/ARW and Netpbm
+    /// variants), so an exhaustive switch is more churn than it's
+    /// worth. We uppercase the raw value and append "(animated)" for
+    /// formats that carry frames over time — enough information for
+    /// the picker without a translation table.
+    var displayLabel: String {
+        let upper = rawValue.uppercased()
+        return isAnimated ? "\(upper) (animated)" : upper
+    }
+}
+
+private extension EditabilityPreset {
+    var displayLabel: String {
+        switch self {
+        case .logoIcon:          return "Logo / Icon"
+        case .illustration:      return "Illustration"
+        case .photorealistic:    return "Photorealistic"
+        case .technicalDiagram:  return "Technical Diagram"
+        case .handDrawnSketch:   return "Hand-drawn Sketch"
+        case .custom:            return "Custom"
+        }
+    }
+}
+
+private extension TracingMode {
+    var displayLabel: String {
+        switch self {
+        case .outline:           return "Outline"
+        case .colorQuantization: return "Colour Quantisation"
+        case .monochrome:        return "Monochrome"
+        case .photorealistic:    return "Photorealistic"
+        }
+    }
+}
+
+private extension AlphaStrategy {
+    var displayLabel: String {
+        switch self {
+        case .clipPathWithOpacity: return "Clip-path with opacity"
+        case .flatten:             return "Flatten against background"
+        case .discard:             return "Discard alpha"
+        }
+    }
+}
+
+private extension AnimationMethod {
+    var displayLabel: String {
+        switch self {
+        case .smil:                 return "SMIL"
+        case .cssKeyframes:         return "CSS @keyframes"
+        case .hybrid:               return "Hybrid (SMIL + CSS)"
+        case .staticFrameSequence:  return "Static frame sequence"
+        }
+    }
+}

--- a/Tests/ConverterEngineTests/ConverterEngineTests.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests.swift
@@ -10532,6 +10532,74 @@ final class ConverterEngineTests: XCTestCase {
         }
     }
 
+    // MARK: - RasterToVectorConfig + VectorConversionView (#376 / #381 / #402)
+
+    /// Pins the per-preset auto-drive table that `VectorConversionView`'s
+    /// `applyPreset(_:)` relies on. If the engine adds, removes, or
+    /// re-labels a preset, this test fails immediately rather than
+    /// leaving the UI silently broken.
+    func test_editabilityPreset_defaultTracingModeAndColorCount() {
+        XCTAssertEqual(EditabilityPreset.logoIcon.defaultTracingMode, .outline)
+        XCTAssertEqual(EditabilityPreset.logoIcon.defaultColorCount, 8)
+
+        XCTAssertEqual(EditabilityPreset.illustration.defaultTracingMode, .colorQuantization)
+        XCTAssertEqual(EditabilityPreset.illustration.defaultColorCount, 32)
+
+        XCTAssertEqual(EditabilityPreset.photorealistic.defaultTracingMode, .photorealistic)
+        XCTAssertEqual(EditabilityPreset.photorealistic.defaultColorCount, 256)
+
+        XCTAssertEqual(EditabilityPreset.technicalDiagram.defaultTracingMode, .outline)
+        XCTAssertEqual(EditabilityPreset.technicalDiagram.defaultColorCount, 4)
+
+        XCTAssertEqual(EditabilityPreset.handDrawnSketch.defaultTracingMode, .colorQuantization)
+        XCTAssertEqual(EditabilityPreset.handDrawnSketch.defaultColorCount, 16)
+    }
+
+    /// Verifies every enum the UI reads from has stable rawValues for
+    /// `@AppStorage` persistence. A rename in the engine would otherwise
+    /// silently invalidate every user's persisted preference.
+    func test_rasterToVectorEnums_rawValuesAreStableForAppStorage() {
+        // Pinned values match the UI AppStorage default strings in
+        // VectorConversionView.swift.
+        XCTAssertEqual(RasterFormat.png.rawValue, "png")
+        XCTAssertEqual(EditabilityPreset.illustration.rawValue, "illustration")
+        XCTAssertEqual(TracingMode.colorQuantization.rawValue, "color_quantization")
+        XCTAssertEqual(AlphaStrategy.clipPathWithOpacity.rawValue, "clip_path_with_opacity")
+        XCTAssertEqual(AnimationMethod.smil.rawValue, "smil")
+    }
+
+    /// Verifies the engine's `RasterToVectorConfig` default-init agrees
+    /// with the AppStorage defaults the UI installs on first launch.
+    /// Drift between the two would mean a user who never opens the view
+    /// gets a different config than an engine consumer using the
+    /// type's defaults.
+    func test_rasterToVectorConfig_defaultsMatchUIAppStorage() {
+        let defaults = RasterToVectorConfig(inputFormat: .png)
+        XCTAssertEqual(defaults.preset, .illustration)
+        XCTAssertEqual(defaults.tracingMode, .colorQuantization)
+        XCTAssertEqual(defaults.colorCount, 32,
+                       "illustration preset.defaultColorCount is 32")
+        XCTAssertEqual(defaults.alpha, .clipPathWithOpacity)
+        XCTAssertEqual(defaults.animation, .smil)
+        XCTAssertTrue(defaults.preserveMetadata)
+        XCTAssertFalse(defaults.ocrTextRegions)
+        XCTAssertEqual(defaults.curveSimplification, 2.0)
+    }
+
+    /// `RasterFormat.isAnimated` drives whether the UI shows the
+    /// Animation section. Pin the animated set so a future addition
+    /// of e.g. `.heicSequence` doesn't sneak past the static-only path.
+    func test_rasterFormat_isAnimatedMatchesUIExpectations() {
+        XCTAssertTrue(RasterFormat.gif.isAnimated)
+        XCTAssertTrue(RasterFormat.apng.isAnimated)
+        XCTAssertTrue(RasterFormat.webp.isAnimated)
+        // Common single-frame formats must NOT be flagged animated —
+        // otherwise the UI would show a meaningless animation picker.
+        XCTAssertFalse(RasterFormat.png.isAnimated)
+        XCTAssertFalse(RasterFormat.jpeg.isAnimated)
+        XCTAssertFalse(RasterFormat.tiff.isAnimated)
+    }
+
     // MARK: - AccurateRip SubmissionConfig (#381 / #400)
 
     /// Pins the `AccurateRipVerifier.SubmissionConfig` default-initialised


### PR DESCRIPTION
## Summary

Priority-2 sub-task of [#381](../issues/381) — first of two. Lands a new SwiftUI surface for raster→vector (SVG) conversion, binding the eight user-facing fields of \`RasterToVectorConfig\`. Tracking: [#402](../issues/402).

## Changes

### Navigation wiring

- New \`vectorConversion = "Vector Conversion"\` case in [AppViewModel.swift](Sources/MeedyaConverter/ViewModels/AppViewModel.swift) sidebar enum, slotted into Tools between Images and Burn.
- SF Symbol \`scribble.variable\` + accessibility tooltip.
- Switch dispatch in [ContentView.swift](Sources/MeedyaConverter/Views/ContentView.swift).

### New view

[Sources/MeedyaConverter/Views/VectorConversionView.swift](Sources/MeedyaConverter/Views/VectorConversionView.swift) — Form with six sections:

| Section | Controls | Notes |
|---------|----------|-------|
| Input | Raster format picker | Drives whether Animation section is rendered |
| Preset | Editability preset picker (6 cases) | Auto-drives tracing mode + colour count, except for \`.custom\` which preserves hand-tuned values |
| Tracing | Mode picker (4 cases) + colour count stepper (2–256) | Colour count disabled for outline/monochrome modes |
| Alpha | Strategy picker (3 cases, inline style) | |
| Animation | Method picker (4 cases) | **Only rendered when input format is animated** |
| Other | Metadata toggle, OCR toggle, curve simplification (0.0–10.0, step 0.5) | |

### Persistence

Nine \`@AppStorage\` keys under the \`vectorConversion.\` namespace, one per \`RasterToVectorConfig\` field. Per-field (not JSON blob) so a future engine field doesn't invalidate user settings. Every enum binding has a corrupt-rawValue fallback to the engine default.

### Display names

Kept in this view file (not on engine enums) because they are purely UI strings. \`RasterFormat\` has ~30 cases including raw camera formats — the label uppercases the rawValue and appends "(animated)" for animated formats, sparing us a brittle 30-case switch.

### Tests

- \`test_editabilityPreset_defaultTracingModeAndColorCount\` — pins the auto-drive table.
- \`test_rasterToVectorEnums_rawValuesAreStableForAppStorage\` — protects user preferences from engine renames.
- \`test_rasterToVectorConfig_defaultsMatchUIAppStorage\` — UI defaults agree with engine \`init\` defaults.
- \`test_rasterFormat_isAnimatedMatchesUIExpectations\` — protects the Animation-section conditional.

## #381 progress

- [x] **#1 SubtitleTonemap** — PR #397 merged
- [x] **#5 SuiteCoreMetadataBackend** — PR #399 merged
- [x] **#6 AccurateRip submission** — PR #401 merged
- [x] **#2 RasterToVectorConfig** → new VectorConversionView (this PR)
- [ ] **#3 ProResToVectorConfig** → new ProResVectorView (priority-2, next; will embed this view's surface)
- [ ] **#4 RenderFarmClient.Configuration** → new Render Farm tab (priority-3, gated on #346 transport)

## Test plan

- [x] \`swift build\` clean.
- [x] 4 new tests pass.
- [ ] After merge: open Tools → Vector Conversion, exercise the preset auto-drive, toggle the Animation section by switching between png and gif, verify settings persist across launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)