### PR TITLE
Add ProResVectorView under Tools menu + factor reusable editor (part of #381, addresses #404)

### DIFF
--- a/Sources/MeedyaConverter/ViewModels/AppViewModel.swift
+++ b/Sources/MeedyaConverter/ViewModels/AppViewModel.swift
@@ -51,6 +51,9 @@ enum NavigationItem: String, CaseIterable, Identifiable {
     /// Raster → vector (SVG) conversion. Issues #376 engine / #381 / #402 UI.
     case vectorConversion = "Vector Conversion"
 
+    /// ProRes → animated SVG conversion. Issues #377 engine / #381 / #404 UI.
+    case proresVector = "ProRes to Vector"
+
     /// Disc burning — write to physical optical media.
     case burn = "Burn"
 
@@ -140,6 +143,7 @@ enum NavigationItem: String, CaseIterable, Identifiable {
         case .resourceMonitor:   return "gauge.with.dots.needle.33percent"
         case .images:            return "photo.on.rectangle.angled"
         case .vectorConversion:  return "scribble.variable"
+        case .proresVector:      return "film.fill"
         case .burn:              return "opticaldisc"
         case .trimEdit:          return "scissors"
         case .analyze:           return "waveform.and.magnifyingglass"
@@ -179,6 +183,7 @@ enum NavigationItem: String, CaseIterable, Identifiable {
         case .resourceMonitor:   return "Monitor system resources"
         case .images:            return "Convert images"
         case .vectorConversion:  return "Convert raster images to vector SVG"
+        case .proresVector:      return "Convert ProRes 4444 video to animated SVG"
         case .burn:              return "Burn disc"
         case .trimEdit:          return "Trim and edit video"
         case .analyze:           return "Analyse media files"

--- a/Sources/MeedyaConverter/Views/ContentView.swift
+++ b/Sources/MeedyaConverter/Views/ContentView.swift
@@ -100,6 +100,8 @@ struct ContentView: View {
             ImageConversionView()
         case .vectorConversion:
             VectorConversionView()
+        case .proresVector:
+            ProResVectorView()
         case .burn:
             BurnSettingsView()
         case .trimEdit:

--- a/Sources/MeedyaConverter/Views/ProResVectorView.swift
+++ b/Sources/MeedyaConverter/Views/ProResVectorView.swift
@@ -1,0 +1,350 @@
+// ============================================================================
+// MeedyaConverter — ProResVectorView
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+//
+// SwiftUI surface for ProRes 4444 → animated SVG conversion. Binds the
+// fields of `ProResToVectorConfig`, embeds the shared
+// `RasterToVectorConfigEditor` for per-frame tracing settings, and
+// surfaces an output-size warning when the chosen settings would produce
+// very large SVG output.
+//
+// Layout:
+//   1. Source       — ProRes variant, frame rate, time range, frame stride
+//   2. Alpha        — How the ProRes alpha channel is represented in the SVG
+//   3. Tracing      — Embedded RasterToVectorConfigEditor (no Animation section
+//                     because the outer config has its own animation method)
+//   4. Animation    — Outer-SVG animation method (separate from per-frame tracing)
+//   5. Assembly     — Shape persistence + keyframe extraction toggles
+//   6. Warning      — Heads-up callout when settings would produce a large SVG
+//
+// GitHub Issues: #377 engine (ProResToVectorConverter) / #381 / #404 UI.
+// ============================================================================
+
+import SwiftUI
+import ConverterEngine
+
+// MARK: - ProResVectorView
+
+/// User-facing settings for ProRes 4444 → animated SVG conversion.
+struct ProResVectorView: View {
+
+    // -----------------------------------------------------------------
+    // MARK: - Persisted state
+    // -----------------------------------------------------------------
+    //
+    // One AppStorage key per ProResToVectorConfig field (top-level
+    // + the nested tracing fields). Per-field keys (rather than a
+    // JSON-encoded blob) mean a future addition to the engine config
+    // does not invalidate the user's existing preferences. All keys
+    // are namespaced under `proresVector.` so they are easy to grep
+    // for, clear in tests, and distinguish from `vectorConversion.`
+    // keys (which back the stand-alone Vector Conversion tool).
+    //
+    // The tracing-config fields live alongside the ProRes fields in
+    // the same `proresVector.` namespace because the user's
+    // tracing-related preferences for ProRes work may legitimately
+    // differ from their stand-alone Vector Conversion preferences
+    // (different source material, different goals).
+
+    // ProRes-specific fields
+    @AppStorage("proresVector.sourceVariant") private var rawSourceVariant: String =
+        ProResVariant.proRes4444.rawValue
+    @AppStorage("proresVector.frameRate") private var rawFrameRate: String =
+        ProResFrameRate.fps24.rawValue
+    @AppStorage("proresVector.startTimeSeconds") private var startTimeSeconds: Double = 0.0
+    /// Sentinel value -1 means "unbounded — until end of clip". A real
+    /// end-time of -1 is impossible in this domain, so the sentinel is
+    /// unambiguous and avoids storing an optional in AppStorage (which
+    /// does not natively support `Optional<Double>`).
+    @AppStorage("proresVector.endTimeSeconds") private var endTimeSeconds: Double = -1.0
+    @AppStorage("proresVector.frameStride") private var frameStride: Int = 1
+    @AppStorage("proresVector.alphaHandling") private var rawAlphaHandling: String =
+        ProResAlphaHandling.preservePerFrame.rawValue
+    @AppStorage("proresVector.animation") private var rawAnimation: String =
+        AnimationMethod.smil.rawValue
+    @AppStorage("proresVector.shapePersistence") private var shapePersistence: Bool = true
+    @AppStorage("proresVector.keyframeExtraction") private var keyframeExtraction: Bool = true
+
+    // Nested tracing-config fields (mirrors RasterToVectorConfig's fields)
+    @AppStorage("proresVector.tracing.preset") private var rawTracingPreset: String =
+        EditabilityPreset.illustration.rawValue
+    @AppStorage("proresVector.tracing.tracingMode") private var rawTracingMode: String =
+        TracingMode.colorQuantization.rawValue
+    @AppStorage("proresVector.tracing.colorCount") private var tracingColorCount: Int = 32
+    @AppStorage("proresVector.tracing.alpha") private var rawTracingAlpha: String =
+        AlphaStrategy.clipPathWithOpacity.rawValue
+    @AppStorage("proresVector.tracing.preserveMetadata") private var tracingPreserveMetadata: Bool = true
+    @AppStorage("proresVector.tracing.ocrTextRegions") private var tracingOcrTextRegions: Bool = false
+    @AppStorage("proresVector.tracing.curveSimplification") private var tracingCurveSimplification: Double = 2.0
+
+    // -----------------------------------------------------------------
+    // MARK: - Computed bindings
+    // -----------------------------------------------------------------
+
+    private var sourceVariant: Binding<ProResVariant> {
+        Binding(
+            get: { ProResVariant(rawValue: rawSourceVariant) ?? .proRes4444 },
+            set: { rawSourceVariant = $0.rawValue }
+        )
+    }
+
+    private var frameRate: Binding<ProResFrameRate> {
+        Binding(
+            get: { ProResFrameRate(rawValue: rawFrameRate) ?? .fps24 },
+            set: { rawFrameRate = $0.rawValue }
+        )
+    }
+
+    private var alphaHandling: Binding<ProResAlphaHandling> {
+        Binding(
+            get: { ProResAlphaHandling(rawValue: rawAlphaHandling) ?? .preservePerFrame },
+            set: { rawAlphaHandling = $0.rawValue }
+        )
+    }
+
+    private var animation: Binding<AnimationMethod> {
+        Binding(
+            get: { AnimationMethod(rawValue: rawAnimation) ?? .smil },
+            set: { rawAnimation = $0.rawValue }
+        )
+    }
+
+    /// Assembles the per-frame tracing AppStorage values into a
+    /// `Binding<RasterToVectorConfig>` for the shared editor. The input
+    /// format is hard-coded to PNG because the ProRes pipeline always
+    /// extracts intermediate PNG frames.
+    private var tracingConfig: Binding<RasterToVectorConfig> {
+        Binding(
+            get: {
+                RasterToVectorConfig(
+                    inputFormat: .png,
+                    outputFormat: .svg2,
+                    tracingMode: TracingMode(rawValue: rawTracingMode) ?? .colorQuantization,
+                    preset: EditabilityPreset(rawValue: rawTracingPreset) ?? .illustration,
+                    colorCount: tracingColorCount,
+                    alpha: AlphaStrategy(rawValue: rawTracingAlpha) ?? .clipPathWithOpacity,
+                    animation: .smil, // tracing's animation is unused in ProRes mode
+                    preserveMetadata: tracingPreserveMetadata,
+                    ocrTextRegions: tracingOcrTextRegions,
+                    curveSimplification: tracingCurveSimplification
+                )
+            },
+            set: { newValue in
+                rawTracingMode = newValue.tracingMode.rawValue
+                rawTracingPreset = newValue.preset.rawValue
+                tracingColorCount = newValue.colorCount
+                rawTracingAlpha = newValue.alpha.rawValue
+                tracingPreserveMetadata = newValue.preserveMetadata
+                tracingOcrTextRegions = newValue.ocrTextRegions
+                tracingCurveSimplification = newValue.curveSimplification
+            }
+        )
+    }
+
+    /// Assembles the full `ProResToVectorConfig` for the output-size
+    /// warning check. We do not persist this as a single blob — it is
+    /// derived from the AppStorage values for the warning call only.
+    private var assembledConfig: ProResToVectorConfig {
+        ProResToVectorConfig(
+            sourceVariant: sourceVariant.wrappedValue,
+            frameRate: frameRate.wrappedValue,
+            startTimeSeconds: startTimeSeconds > 0 ? startTimeSeconds : nil,
+            endTimeSeconds: endTimeSeconds >= 0 ? endTimeSeconds : nil,
+            frameStride: frameStride,
+            alphaHandling: alphaHandling.wrappedValue,
+            tracing: tracingConfig.wrappedValue,
+            animation: animation.wrappedValue,
+            shapePersistence: shapePersistence,
+            keyframeExtraction: keyframeExtraction
+        )
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Body
+    // -----------------------------------------------------------------
+
+    var body: some View {
+        Form {
+            Section("Source") {
+                Picker("ProRes variant", selection: sourceVariant) {
+                    ForEach(ProResVariant.allCases, id: \.self) { variant in
+                        Text(variant.displayName).tag(variant)
+                    }
+                }
+                .accessibilityLabel("ProRes variant of the source file")
+
+                Picker("Frame rate", selection: frameRate) {
+                    ForEach(ProResFrameRate.allCases, id: \.self) { rate in
+                        Text("\(rate.rawValue) fps").tag(rate)
+                    }
+                }
+                .accessibilityLabel("Frame rate at which to sample the source")
+
+                Stepper(
+                    value: $startTimeSeconds,
+                    in: 0...3600,
+                    step: 0.5
+                ) {
+                    HStack {
+                        Text("Start time")
+                        Spacer()
+                        Text(String(format: "%.1f s", startTimeSeconds))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                .accessibilityLabel("Start timecode in seconds; 0 means clip start")
+
+                Stepper(
+                    value: $endTimeSeconds,
+                    in: -1...3600,
+                    step: 0.5
+                ) {
+                    HStack {
+                        Text("End time")
+                        Spacer()
+                        Text(endTimeSeconds < 0
+                             ? "until end of clip"
+                             : String(format: "%.1f s", endTimeSeconds))
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                .accessibilityLabel(
+                    "End timecode in seconds; -1 means run until end of clip"
+                )
+
+                Stepper(
+                    value: $frameStride,
+                    in: 1...10,
+                    step: 1
+                ) {
+                    HStack {
+                        Text("Frame stride")
+                        Spacer()
+                        Text("every \(frameStride) frame\(frameStride == 1 ? "" : "s")")
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                .accessibilityLabel(
+                    "Process every Nth frame; 1 means every frame"
+                )
+            }
+
+            Section("Alpha") {
+                Picker("Handling", selection: alphaHandling) {
+                    ForEach(ProResAlphaHandling.allCases, id: \.self) { strategy in
+                        Text(strategy.displayLabel).tag(strategy)
+                    }
+                }
+                .pickerStyle(.inline)
+                .accessibilityLabel("How to handle the ProRes alpha channel")
+            }
+
+            // Embedded per-frame tracing editor. We pass `.png` as the
+            // input format because the ProRes pipeline always extracts
+            // PNG intermediate frames. `showAnimationSection: false`
+            // because the outer ProRes config has its own animation
+            // method (see the Animation section below).
+            RasterToVectorConfigEditor(
+                config: tracingConfig,
+                inputFormat: .png,
+                showAnimationSection: false
+            )
+
+            Section("Animation") {
+                Picker("Method", selection: animation) {
+                    ForEach(AnimationMethod.allCases, id: \.self) { method in
+                        Text(method.displayLabel).tag(method)
+                    }
+                }
+                .accessibilityLabel("Animation method for the assembled SVG")
+            }
+
+            Section("Assembly") {
+                Toggle("Shape persistence", isOn: $shapePersistence)
+                    .accessibilityLabel(
+                        "Track shape identity across frames for "
+                        + "consistent SVG element IDs"
+                    )
+
+                Toggle("Keyframe extraction", isOn: $keyframeExtraction)
+                    .accessibilityLabel(
+                        "Only re-trace significant visual changes; "
+                        + "animate between keyframes"
+                    )
+            }
+
+            // Output-size warning. The engine's `shouldWarnAboutOutputSize`
+            // needs a source duration to compute the projected frame count.
+            // We don't have a selected file in this tool view, so we use
+            // the engine's `recommendedMaxDurationSeconds` as the
+            // reference — the warning fires when the user's settings
+            // would produce more than that many seconds of output, OR
+            // when they've selected photorealistic tracing (which is
+            // always heavy regardless of length).
+            if outputSizeWarningFires {
+                Section {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Output size may be large")
+                                .font(.subheadline.bold())
+                            Text(
+                                "These settings can produce very large SVG "
+                                + "files. Consider increasing the frame "
+                                + "stride, narrowing the time range, or "
+                                + "switching to a non-photorealistic "
+                                + "tracing mode."
+                            )
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("ProRes to Vector")
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Output-size warning
+    // -----------------------------------------------------------------
+
+    /// Whether the warning callout should be visible. Delegates to
+    /// `ProResToVectorConverter.shouldWarnAboutOutputSize(...)` with a
+    /// synthetic reference duration of
+    /// `ProResToVectorConverter.recommendedMaxDurationSeconds * 2` —
+    /// twice the engine's "comfortable" duration — so the warning
+    /// fires for any settings that would produce more than the
+    /// engine's recommended cap of output.
+    private var outputSizeWarningFires: Bool {
+        let referenceDuration = ProResToVectorConverter
+            .recommendedMaxDurationSeconds * 2
+        return ProResToVectorConverter.shouldWarnAboutOutputSize(
+            config: assembledConfig,
+            sourceDurationSeconds: referenceDuration
+        )
+    }
+}
+
+// MARK: - Display-name helpers
+//
+// Engine enums that don't already have a `displayName` or `displayLabel`
+// helper from RasterToVectorConfigEditor.swift get their UI labels here.
+
+private extension ProResAlphaHandling {
+    var displayLabel: String {
+        switch self {
+        case .preservePerFrame: return "Preserve per-frame (clip-paths)"
+        case .alphaMatteOnly:   return "Alpha matte only (monochrome)"
+        case .flatten:          return "Flatten against background"
+        }
+    }
+}

--- a/Sources/MeedyaConverter/Views/RasterToVectorConfigEditor.swift
+++ b/Sources/MeedyaConverter/Views/RasterToVectorConfigEditor.swift
@@ -1,0 +1,264 @@
+// ============================================================================
+// MeedyaConverter — RasterToVectorConfigEditor
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+//
+// Reusable SwiftUI editor for a `RasterToVectorConfig`. Renders the Preset,
+// Tracing, Alpha, optional Animation, and Other sections — the parts of the
+// raster→vector configuration surface that are common to:
+//
+//   * `VectorConversionView` (Tools → Vector Conversion)
+//   * `ProResVectorView`     (Tools → ProRes Vector) — embeds this editor
+//                                                     for per-frame tracing
+//
+// Persistence is intentionally OUT of scope here — the editor is purely
+// binding-driven. Callers are responsible for storing the underlying
+// `RasterToVectorConfig` (whether in AppStorage, in a parent config, or
+// in a profile JSON blob).
+//
+// GitHub Issues: #376 engine / #381 / #402 (Vector Conversion) / #404
+// (ProRes Vector — the consumer that drove the refactor).
+// ============================================================================
+
+import SwiftUI
+import ConverterEngine
+
+// MARK: - RasterToVectorConfigEditor
+
+/// Sections of the raster→vector configuration that are shared between
+/// the stand-alone Vector Conversion tool and the per-frame tracing
+/// stage of the ProRes Vector tool.
+struct RasterToVectorConfigEditor: View {
+
+    // -----------------------------------------------------------------
+    // MARK: - Inputs
+    // -----------------------------------------------------------------
+
+    /// The config the editor mutates. The parent owns persistence.
+    @Binding var config: RasterToVectorConfig
+
+    /// The current input raster format. The editor only needs this to
+    /// decide whether the Animation section is meaningful (it's only
+    /// rendered for animated raster inputs in the stand-alone view).
+    /// For ProRes use, the parent always passes `.png` and disables
+    /// the Animation section via `showAnimationSection: false` anyway.
+    let inputFormat: RasterFormat
+
+    /// Whether to render the Animation section. The stand-alone Vector
+    /// Conversion tool drives this from `inputFormat.isAnimated`; the
+    /// ProRes Vector tool sets it to `false` because the outer
+    /// `ProResToVectorConfig` has its own animation method that takes
+    /// precedence.
+    let showAnimationSection: Bool
+
+    // -----------------------------------------------------------------
+    // MARK: - Body
+    // -----------------------------------------------------------------
+
+    var body: some View {
+        Section("Preset") {
+            Picker("Editability preset", selection: presetBinding) {
+                ForEach(EditabilityPreset.allCases, id: \.self) { preset in
+                    Text(preset.displayLabel).tag(preset)
+                }
+            }
+            .accessibilityLabel("Editability preset for the traced SVG")
+
+            Text(
+                "Picking a preset auto-fills tracing mode and colour "
+                + "count. Choose Custom to keep your manual values."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
+        Section("Tracing") {
+            Picker("Mode", selection: $config.tracingMode) {
+                ForEach(TracingMode.allCases, id: \.self) { mode in
+                    Text(mode.displayLabel).tag(mode)
+                }
+            }
+            .accessibilityLabel("Tracing algorithm")
+
+            Stepper(
+                value: $config.colorCount,
+                in: 2...256,
+                step: 1
+            ) {
+                HStack {
+                    Text("Colour count")
+                    Spacer()
+                    Text("\(config.colorCount)")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+            .accessibilityLabel("Number of colours for quantisation tracing")
+            .disabled(!colorCountApplies(to: config.tracingMode))
+        }
+
+        Section("Alpha") {
+            Picker("Strategy", selection: $config.alpha) {
+                ForEach(AlphaStrategy.allCases, id: \.self) { strategy in
+                    Text(strategy.displayLabel).tag(strategy)
+                }
+            }
+            .pickerStyle(.inline)
+            .accessibilityLabel("Alpha-channel handling strategy")
+        }
+
+        if showAnimationSection {
+            Section("Animation") {
+                // NOTE: an explicit binding closure here works around a
+                // collision between `RasterToVectorConfig.animation`
+                // (the field we want to mutate) and SwiftUI's
+                // `Binding.animation(_:)` method, which the dynamic-
+                // member-lookup machinery prefers on `$config.animation`.
+                Picker("Method", selection: animationBinding) {
+                    ForEach(AnimationMethod.allCases, id: \.self) { method in
+                        Text(method.displayLabel).tag(method)
+                    }
+                }
+                .accessibilityLabel("Animation method for animated input")
+            }
+        }
+
+        Section("Other") {
+            Toggle("Preserve EXIF / IPTC / XMP metadata", isOn: $config.preserveMetadata)
+                .accessibilityLabel(
+                    "Copy source metadata into the SVG metadata block"
+                )
+
+            Toggle("OCR text regions", isOn: $config.ocrTextRegions)
+                .accessibilityLabel(
+                    "Detect text regions and emit them as SVG text "
+                    + "elements instead of traced paths"
+                )
+
+            Stepper(
+                value: $config.curveSimplification,
+                in: 0.0...10.0,
+                step: 0.5
+            ) {
+                HStack {
+                    Text("Curve simplification")
+                    Spacer()
+                    Text(String(format: "%.1f", config.curveSimplification))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+            .accessibilityLabel(
+                "Curve-simplification tolerance; 0 preserves every "
+                + "point, 10 smooths aggressively"
+            )
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Preset auto-drive
+    // -----------------------------------------------------------------
+
+    /// Explicit binding for `config.animation`. See the note in the
+    /// Animation section above for why `$config.animation` cannot be
+    /// used directly.
+    private var animationBinding: Binding<AnimationMethod> {
+        Binding(
+            get: { config.animation },
+            set: { config.animation = $0 }
+        )
+    }
+
+    /// Bridging binding for the preset picker. Reading is straightforward;
+    /// writing triggers the auto-drive of `tracingMode` and `colorCount`
+    /// (except for `.custom`, which preserves the user's hand-tuned
+    /// values).
+    private var presetBinding: Binding<EditabilityPreset> {
+        Binding(
+            get: { config.preset },
+            set: { newPreset in
+                config.preset = newPreset
+                if newPreset != .custom {
+                    config.tracingMode = newPreset.defaultTracingMode
+                    config.colorCount = newPreset.defaultColorCount
+                }
+            }
+        )
+    }
+
+    /// Whether the colour-count stepper has any effect under the given
+    /// tracing mode. Outline and monochrome ignore colour count by
+    /// construction; colour-quantisation and photorealistic respect it.
+    private func colorCountApplies(to mode: TracingMode) -> Bool {
+        switch mode {
+        case .outline, .monochrome:               return false
+        case .colorQuantization, .photorealistic: return true
+        }
+    }
+}
+
+// MARK: - Display-name helpers
+//
+// User-facing labels for the engine enums. Centralised here so both
+// `VectorConversionView` and `ProResVectorView` use identical strings.
+// `internal` visibility — these are intentionally not part of the
+// engine's public API.
+
+extension RasterFormat {
+    /// User-facing label. `RasterFormat` covers ~30 cases (common web
+    /// formats plus raw camera formats like CR2/NEF/ARW and Netpbm
+    /// variants), so an exhaustive switch is more churn than it's worth.
+    /// We uppercase the raw value and append "(animated)" for formats
+    /// that carry frames over time.
+    var displayLabel: String {
+        let upper = rawValue.uppercased()
+        return isAnimated ? "\(upper) (animated)" : upper
+    }
+}
+
+extension EditabilityPreset {
+    var displayLabel: String {
+        switch self {
+        case .logoIcon:         return "Logo / Icon"
+        case .illustration:     return "Illustration"
+        case .photorealistic:   return "Photorealistic"
+        case .technicalDiagram: return "Technical Diagram"
+        case .handDrawnSketch:  return "Hand-drawn Sketch"
+        case .custom:           return "Custom"
+        }
+    }
+}
+
+extension TracingMode {
+    var displayLabel: String {
+        switch self {
+        case .outline:           return "Outline"
+        case .colorQuantization: return "Colour Quantisation"
+        case .monochrome:        return "Monochrome"
+        case .photorealistic:    return "Photorealistic"
+        }
+    }
+}
+
+extension AlphaStrategy {
+    var displayLabel: String {
+        switch self {
+        case .clipPathWithOpacity: return "Clip-path with opacity"
+        case .flatten:             return "Flatten against background"
+        case .discard:             return "Discard alpha"
+        }
+    }
+}
+
+extension AnimationMethod {
+    var displayLabel: String {
+        switch self {
+        case .smil:                return "SMIL"
+        case .cssKeyframes:        return "CSS @keyframes"
+        case .hybrid:              return "Hybrid (SMIL + CSS)"
+        case .staticFrameSequence: return "Static frame sequence"
+        }
+    }
+}

--- a/Sources/MeedyaConverter/Views/VectorConversionView.swift
+++ b/Sources/MeedyaConverter/Views/VectorConversionView.swift
@@ -5,28 +5,12 @@
 // of this file, via any medium, is strictly prohibited.
 // ============================================================================
 //
-// SwiftUI surface for raster→vector (SVG) conversion. Binds the eight
-// user-facing fields of `RasterToVectorConfig` from `ConverterEngine` and
-// persists the user's preferences via `@AppStorage`.
+// SwiftUI surface for raster→vector (SVG) conversion. Persists the user's
+// preferences across launches via `@AppStorage`, then assembles them into a
+// `RasterToVectorConfig` binding consumed by the reusable
+// `RasterToVectorConfigEditor` (shared with `ProResVectorView`).
 //
-// Layout:
-//   1. Input    — Raster format picker (the only purely informational
-//                 control: the actual format is detected from the file).
-//   2. Preset   — Editability preset picker. Changing this auto-drives
-//                 the tracing mode and colour count to the preset's
-//                 recommended defaults, so users who pick a preset don't
-//                 need to fiddle with the lower-level controls.
-//   3. Tracing  — Tracing mode picker + colour count stepper. Colour
-//                 count is disabled when the tracing mode doesn't use it
-//                 (outline / monochrome — those produce a fixed number
-//                 of regions).
-//   4. Alpha    — Alpha strategy picker.
-//   5. Animation — Animation method picker, hidden unless the chosen
-//                  input format is animated (GIF / APNG / animated WebP).
-//   6. Extras   — Preserve metadata toggle, OCR toggle, curve
-//                 simplification stepper.
-//
-// GitHub Issues: #376 engine (RasterVectorConverter) / #381 / #402 UI.
+// GitHub Issues: #376 engine / #381 / #402 UI.
 // ============================================================================
 
 import SwiftUI
@@ -44,57 +28,33 @@ struct VectorConversionView: View {
     // One AppStorage key per RasterToVectorConfig field. Per-field keys
     // (rather than a JSON-encoded blob) mean a future addition to the
     // engine config does not invalidate the user's existing preferences.
-    // The keys are namespaced under `vectorConversion.` so they are easy
-    // to grep for and to clear in tests.
+    // The keys are namespaced under `vectorConversion.` so they are
+    // easy to grep for and to clear in tests.
+    //
+    // The values here are the *AppStorage representation* — String for
+    // enum rawValues, primitive for everything else. They are bridged
+    // into a `Binding<RasterToVectorConfig>` for the shared editor.
 
-    /// Raster input format. Defaulted to PNG — the most common case —
-    /// so the form has a stable initial state.
     @AppStorage("vectorConversion.inputFormat") private var rawInputFormat: String =
         RasterFormat.png.rawValue
-
-    /// Editability preset. Changing this auto-drives `rawTracingMode`
-    /// and `colorCount` (see `applyPreset(_:)`).
     @AppStorage("vectorConversion.preset") private var rawPreset: String =
         EditabilityPreset.illustration.rawValue
-
-    /// Tracing mode. Initialised to the default for `illustration` so
-    /// the AppStorage default agrees with the engine's RasterToVectorConfig
-    /// default-init (pinned by a test in ConverterEngineTests).
     @AppStorage("vectorConversion.tracingMode") private var rawTracingMode: String =
         TracingMode.colorQuantization.rawValue
-
-    /// Quantisation colour count.
     @AppStorage("vectorConversion.colorCount") private var colorCount: Int = 32
-
-    /// Alpha-channel handling strategy.
     @AppStorage("vectorConversion.alpha") private var rawAlpha: String =
         AlphaStrategy.clipPathWithOpacity.rawValue
-
-    /// Animation method used when the input is an animated raster.
     @AppStorage("vectorConversion.animation") private var rawAnimation: String =
         AnimationMethod.smil.rawValue
-
-    /// Whether to copy EXIF / IPTC / XMP into the SVG `<metadata>` block.
     @AppStorage("vectorConversion.preserveMetadata") private var preserveMetadata: Bool = true
-
-    /// Whether to run OCR against detected text regions and emit them
-    /// as `<text>` elements instead of traced paths.
     @AppStorage("vectorConversion.ocrTextRegions") private var ocrTextRegions: Bool = false
-
-    /// Curve-simplification tolerance. 0.0 = preserve every traced
-    /// point; 10.0 = very aggressive smoothing.
     @AppStorage("vectorConversion.curveSimplification") private var curveSimplification: Double = 2.0
 
     // -----------------------------------------------------------------
     // MARK: - Computed bindings
     // -----------------------------------------------------------------
-    //
-    // Bridge between the raw-String AppStorage values and the
-    // strongly-typed enums consumers actually want to manipulate. Each
-    // binding falls back to the engine's default when the persisted
-    // raw value is unrecognised (e.g. a future build added a case this
-    // binary doesn't know).
 
+    /// Input-format binding with corrupt-rawValue fallback.
     private var inputFormat: Binding<RasterFormat> {
         Binding(
             get: { RasterFormat(rawValue: rawInputFormat) ?? .png },
@@ -102,34 +62,40 @@ struct VectorConversionView: View {
         )
     }
 
-    private var preset: Binding<EditabilityPreset> {
+    /// Assembles the nine AppStorage values into a single
+    /// `Binding<RasterToVectorConfig>` for the shared editor. The
+    /// editor mutates fields on the value type; our setter splits
+    /// the new value back across the nine keys.
+    private var config: Binding<RasterToVectorConfig> {
         Binding(
-            get: { EditabilityPreset(rawValue: rawPreset) ?? .illustration },
-            set: { newPreset in
-                rawPreset = newPreset.rawValue
-                applyPreset(newPreset)
+            get: {
+                RasterToVectorConfig(
+                    inputFormat: RasterFormat(rawValue: rawInputFormat) ?? .png,
+                    outputFormat: .svg2,
+                    tracingMode: TracingMode(rawValue: rawTracingMode) ?? .colorQuantization,
+                    preset: EditabilityPreset(rawValue: rawPreset) ?? .illustration,
+                    colorCount: colorCount,
+                    alpha: AlphaStrategy(rawValue: rawAlpha) ?? .clipPathWithOpacity,
+                    animation: AnimationMethod(rawValue: rawAnimation) ?? .smil,
+                    preserveMetadata: preserveMetadata,
+                    ocrTextRegions: ocrTextRegions,
+                    curveSimplification: curveSimplification
+                )
+            },
+            set: { newValue in
+                // The editor only mutates the user-facing fields; we
+                // do not need to round-trip `inputFormat` or
+                // `outputFormat` here (those are set by the Input
+                // picker below, and `outputFormat` is fixed).
+                rawTracingMode = newValue.tracingMode.rawValue
+                rawPreset = newValue.preset.rawValue
+                colorCount = newValue.colorCount
+                rawAlpha = newValue.alpha.rawValue
+                rawAnimation = newValue.animation.rawValue
+                preserveMetadata = newValue.preserveMetadata
+                ocrTextRegions = newValue.ocrTextRegions
+                curveSimplification = newValue.curveSimplification
             }
-        )
-    }
-
-    private var tracingMode: Binding<TracingMode> {
-        Binding(
-            get: { TracingMode(rawValue: rawTracingMode) ?? .colorQuantization },
-            set: { rawTracingMode = $0.rawValue }
-        )
-    }
-
-    private var alpha: Binding<AlphaStrategy> {
-        Binding(
-            get: { AlphaStrategy(rawValue: rawAlpha) ?? .clipPathWithOpacity },
-            set: { rawAlpha = $0.rawValue }
-        )
-    }
-
-    private var animation: Binding<AnimationMethod> {
-        Binding(
-            get: { AnimationMethod(rawValue: rawAnimation) ?? .smil },
-            set: { rawAnimation = $0.rawValue }
         )
     }
 
@@ -139,6 +105,9 @@ struct VectorConversionView: View {
 
     var body: some View {
         Form {
+            // The Input picker is specific to the stand-alone tool —
+            // ProResVectorView always uses PNG (extracted frames) so
+            // its embedded editor doesn't need this section.
             Section("Input") {
                 Picker("Raster format", selection: inputFormat) {
                     ForEach(RasterFormat.allCases, id: \.self) { format in
@@ -148,198 +117,14 @@ struct VectorConversionView: View {
                 .accessibilityLabel("Input raster format")
             }
 
-            Section("Preset") {
-                Picker("Editability preset", selection: preset) {
-                    ForEach(EditabilityPreset.allCases, id: \.self) { p in
-                        Text(p.displayLabel).tag(p)
-                    }
-                }
-                .accessibilityLabel("Editability preset for the traced SVG")
-
-                Text(
-                    "Picking a preset auto-fills tracing mode and colour "
-                    + "count. Choose Custom to keep your manual values."
-                )
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-
-            Section("Tracing") {
-                Picker("Mode", selection: tracingMode) {
-                    ForEach(TracingMode.allCases, id: \.self) { mode in
-                        Text(mode.displayLabel).tag(mode)
-                    }
-                }
-                .accessibilityLabel("Tracing algorithm")
-
-                // Colour count only applies to colour-quantisation tracing
-                // (and to photorealistic mode, which is a higher-cost
-                // variant). Disable it for outline and monochrome so
-                // users don't waste time tweaking a value that has no
-                // effect on the output.
-                Stepper(
-                    value: $colorCount,
-                    in: 2...256,
-                    step: 1
-                ) {
-                    HStack {
-                        Text("Colour count")
-                        Spacer()
-                        Text("\(colorCount)")
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                    }
-                }
-                .accessibilityLabel("Number of colours for quantisation tracing")
-                .disabled(!colorCountApplies(to: tracingMode.wrappedValue))
-            }
-
-            Section("Alpha") {
-                Picker("Strategy", selection: alpha) {
-                    ForEach(AlphaStrategy.allCases, id: \.self) { strategy in
-                        Text(strategy.displayLabel).tag(strategy)
-                    }
-                }
-                .pickerStyle(.inline)
-                .accessibilityLabel("Alpha-channel handling strategy")
-            }
-
-            // Animation picker is meaningless for static inputs. Render
-            // it only when the chosen input format is animated.
-            if inputFormat.wrappedValue.isAnimated {
-                Section("Animation") {
-                    Picker("Method", selection: animation) {
-                        ForEach(AnimationMethod.allCases, id: \.self) { method in
-                            Text(method.displayLabel).tag(method)
-                        }
-                    }
-                    .accessibilityLabel("Animation method for animated input")
-                }
-            }
-
-            Section("Other") {
-                Toggle("Preserve EXIF / IPTC / XMP metadata", isOn: $preserveMetadata)
-                    .accessibilityLabel(
-                        "Copy source metadata into the SVG metadata block"
-                    )
-
-                Toggle("OCR text regions", isOn: $ocrTextRegions)
-                    .accessibilityLabel(
-                        "Detect text regions and emit them as SVG text "
-                        + "elements instead of traced paths"
-                    )
-
-                Stepper(
-                    value: $curveSimplification,
-                    in: 0.0...10.0,
-                    step: 0.5
-                ) {
-                    HStack {
-                        Text("Curve simplification")
-                        Spacer()
-                        Text(String(format: "%.1f", curveSimplification))
-                            .foregroundStyle(.secondary)
-                            .monospacedDigit()
-                    }
-                }
-                .accessibilityLabel(
-                    "Curve-simplification tolerance; 0 preserves every "
-                    + "point, 10 smooths aggressively"
-                )
-            }
+            // All other sections come from the shared editor.
+            RasterToVectorConfigEditor(
+                config: config,
+                inputFormat: inputFormat.wrappedValue,
+                showAnimationSection: inputFormat.wrappedValue.isAnimated
+            )
         }
         .formStyle(.grouped)
         .navigationTitle("Vector Conversion")
-    }
-
-    // -----------------------------------------------------------------
-    // MARK: - Preset auto-drive
-    // -----------------------------------------------------------------
-
-    /// When a preset is selected, push its recommended tracing mode and
-    /// colour count into the corresponding AppStorage keys so the lower
-    /// controls reflect the preset's intent. We deliberately do NOT
-    /// auto-drive when the preset is `.custom` — that case exists so
-    /// the user can keep their hand-tuned values without losing them
-    /// every time they revisit this view.
-    private func applyPreset(_ newPreset: EditabilityPreset) {
-        guard newPreset != .custom else { return }
-        rawTracingMode = newPreset.defaultTracingMode.rawValue
-        colorCount = newPreset.defaultColorCount
-    }
-
-    /// Whether the colour-count stepper has any effect under the given
-    /// tracing mode. Outline and monochrome ignore colour count by
-    /// construction; colour-quantisation and photorealistic respect it.
-    private func colorCountApplies(to mode: TracingMode) -> Bool {
-        switch mode {
-        case .outline, .monochrome:           return false
-        case .colorQuantization, .photorealistic: return true
-        }
-    }
-}
-
-// MARK: - Display-name helpers
-//
-// User-facing labels for the engine enums. Kept here rather than as
-// `displayName` properties on the engine types because they are purely
-// UI strings — making them part of the engine's public API would force
-// us to keep them in lockstep with translations and SwiftUI conventions.
-
-private extension RasterFormat {
-    /// User-facing label. RasterFormat covers ~30 cases (common web
-    /// formats plus raw camera formats like CR2/NEF/ARW and Netpbm
-    /// variants), so an exhaustive switch is more churn than it's
-    /// worth. We uppercase the raw value and append "(animated)" for
-    /// formats that carry frames over time — enough information for
-    /// the picker without a translation table.
-    var displayLabel: String {
-        let upper = rawValue.uppercased()
-        return isAnimated ? "\(upper) (animated)" : upper
-    }
-}
-
-private extension EditabilityPreset {
-    var displayLabel: String {
-        switch self {
-        case .logoIcon:          return "Logo / Icon"
-        case .illustration:      return "Illustration"
-        case .photorealistic:    return "Photorealistic"
-        case .technicalDiagram:  return "Technical Diagram"
-        case .handDrawnSketch:   return "Hand-drawn Sketch"
-        case .custom:            return "Custom"
-        }
-    }
-}
-
-private extension TracingMode {
-    var displayLabel: String {
-        switch self {
-        case .outline:           return "Outline"
-        case .colorQuantization: return "Colour Quantisation"
-        case .monochrome:        return "Monochrome"
-        case .photorealistic:    return "Photorealistic"
-        }
-    }
-}
-
-private extension AlphaStrategy {
-    var displayLabel: String {
-        switch self {
-        case .clipPathWithOpacity: return "Clip-path with opacity"
-        case .flatten:             return "Flatten against background"
-        case .discard:             return "Discard alpha"
-        }
-    }
-}
-
-private extension AnimationMethod {
-    var displayLabel: String {
-        switch self {
-        case .smil:                 return "SMIL"
-        case .cssKeyframes:         return "CSS @keyframes"
-        case .hybrid:               return "Hybrid (SMIL + CSS)"
-        case .staticFrameSequence:  return "Static frame sequence"
-        }
     }
 }

--- a/Tests/ConverterEngineTests/ConverterEngineTests.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests.swift
@@ -10532,6 +10532,88 @@ final class ConverterEngineTests: XCTestCase {
         }
     }
 
+    // MARK: - ProResToVectorConfig + ProResVectorView (#377 / #381 / #404)
+
+    /// `ProResVectorView` persists its enum fields as their rawValue
+    /// `String`s via `@AppStorage`. Pin the rawValues so a rename on
+    /// the engine side doesn't silently invalidate every user's
+    /// persisted preference.
+    func test_proResEnums_rawValuesAreStableForAppStorage() {
+        XCTAssertEqual(ProResVariant.proRes4444.rawValue, "prores_4444")
+        XCTAssertEqual(ProResVariant.proRes4444XQ.rawValue, "prores_4444_xq")
+        XCTAssertEqual(ProResVariant.proRes4444HDR.rawValue, "prores_4444_hdr")
+
+        XCTAssertEqual(ProResFrameRate.fps23_976.rawValue, "23.976")
+        XCTAssertEqual(ProResFrameRate.fps24.rawValue, "24")
+        XCTAssertEqual(ProResFrameRate.fps29_97.rawValue, "29.97")
+        XCTAssertEqual(ProResFrameRate.fps59_94.rawValue, "59.94")
+
+        XCTAssertEqual(ProResAlphaHandling.preservePerFrame.rawValue, "preserve_per_frame")
+        XCTAssertEqual(ProResAlphaHandling.alphaMatteOnly.rawValue, "alpha_matte_only")
+        XCTAssertEqual(ProResAlphaHandling.flatten.rawValue, "flatten")
+    }
+
+    /// Pins the engine's `ProResToVectorConfig` default-init against the
+    /// AppStorage defaults baked into `ProResVectorView`. Drift would
+    /// mean a user who never opens the view gets a different config
+    /// than an engine consumer using the type's defaults.
+    func test_proResToVectorConfig_defaultsMatchUIAppStorage() {
+        let defaults = ProResToVectorConfig()
+        XCTAssertEqual(defaults.sourceVariant, .proRes4444)
+        XCTAssertEqual(defaults.frameRate, .fps24)
+        XCTAssertNil(defaults.startTimeSeconds,
+                     "UI sentinel of 0 maps to engine nil (clip start)")
+        XCTAssertNil(defaults.endTimeSeconds,
+                     "UI sentinel of -1 maps to engine nil (until end of clip)")
+        XCTAssertEqual(defaults.frameStride, 1)
+        XCTAssertEqual(defaults.alphaHandling, .preservePerFrame)
+        XCTAssertEqual(defaults.animation, .smil)
+        XCTAssertTrue(defaults.shapePersistence)
+        XCTAssertTrue(defaults.keyframeExtraction)
+    }
+
+    /// `ProResVectorView`'s warning callout uses the engine's
+    /// `shouldWarnAboutOutputSize(...)` helper. Verify the helper fires
+    /// when settings select photorealistic tracing regardless of length,
+    /// AND when the projected effective duration exceeds the engine's
+    /// recommended cap.
+    func test_proResToVector_outputSizeWarning_firesAsExpected() {
+        let cap = ProResToVectorConverter.recommendedMaxDurationSeconds
+
+        // Case A — photorealistic tracing always fires the warning.
+        var configA = ProResToVectorConfig()
+        configA.tracing.tracingMode = .photorealistic
+        XCTAssertTrue(
+            ProResToVectorConverter.shouldWarnAboutOutputSize(
+                config: configA,
+                sourceDurationSeconds: 1.0
+            ),
+            "Photorealistic tracing must fire the warning regardless "
+            + "of source duration."
+        )
+
+        // Case B — non-photorealistic tracing on a short clip does NOT fire.
+        var configB = ProResToVectorConfig()
+        configB.tracing.tracingMode = .outline
+        XCTAssertFalse(
+            ProResToVectorConverter.shouldWarnAboutOutputSize(
+                config: configB,
+                sourceDurationSeconds: cap / 2
+            ),
+            "Outline tracing on a sub-cap clip must not fire the warning."
+        )
+
+        // Case C — non-photorealistic tracing on a long clip fires.
+        XCTAssertTrue(
+            ProResToVectorConverter.shouldWarnAboutOutputSize(
+                config: configB,
+                sourceDurationSeconds: cap * 3
+            ),
+            "Effective duration past the recommended cap must fire the "
+            + "warning even for cheap tracing modes."
+        )
+    }
+
     // MARK: - RasterToVectorConfig + VectorConversionView (#376 / #381 / #402)
 
     /// Pins the per-preset auto-drive table that `VectorConversionView`'s


### PR DESCRIPTION
## Summary

Priority-2 sub-task #3 of [#381](../issues/381), completing the priority-2 set. Lands the SwiftUI surface for ProRes 4444 → animated SVG conversion ([engine #377](../issues/377)) and factors out a reusable per-frame tracing editor shared with [VectorConversionView (#403)](../pull/403). Tracking: [#404](../issues/404).

## Changes

### Navigation wiring

- New \`proresVector = "ProRes to Vector"\` case in [AppViewModel.swift](Sources/MeedyaConverter/ViewModels/AppViewModel.swift) Tools section, with SF Symbol \`film.fill\`.
- Switch dispatch in [ContentView.swift](Sources/MeedyaConverter/Views/ContentView.swift).

### New view: ProResVectorView

[Sources/MeedyaConverter/Views/ProResVectorView.swift](Sources/MeedyaConverter/Views/ProResVectorView.swift) — Form with six sections:

| Section | Controls |
|---------|----------|
| Source | ProRes variant, frame rate, start/end timecode steppers, frame stride |
| Alpha | ProRes alpha handling picker (3 cases) |
| Tracing (embedded) | Reused \`RasterToVectorConfigEditor\` — \`showAnimationSection: false\` |
| Animation | Outer-SVG animation method (separate from per-frame tracing) |
| Assembly | Shape persistence + keyframe extraction toggles |
| Warning | Heads-up callout when \`shouldWarnAboutOutputSize(...)\` fires |

**Persistence**: 17 \`@AppStorage\` keys under \`proresVector.\` namespace. Per-field, not JSON blob.

**Sentinel mapping**: \`startTimeSeconds=0\` → engine \`nil\` (clip start); \`endTimeSeconds=-1\` → engine \`nil\` (until end). Avoids the Optional<Double> problem in @AppStorage.

### Refactor: factored RasterToVectorConfigEditor

[Sources/MeedyaConverter/Views/RasterToVectorConfigEditor.swift](Sources/MeedyaConverter/Views/RasterToVectorConfigEditor.swift) — reusable SwiftUI struct that renders the Preset/Tracing/Alpha/optional Animation/Other sections, taking a \`Binding<RasterToVectorConfig>\` plus a \`showAnimationSection\` flag.

\`VectorConversionView\` is rewritten to use the shared editor — its body collapses from a 100+ line Form into an Input section + the editor. Display-label extensions for the engine enums are relocated to the editor file so both views use identical strings.

**Subtle bug found and fixed**: \`$config.animation\` was being resolved as SwiftUI's \`Binding.animation(_:)\` method (which returns a binding-with-animation) rather than a projection into the wrapped \`RasterToVectorConfig.animation\` field. Worked around with an explicit \`animationBinding\` computed property. The other field names don't collide with any \`Binding\` method.

### Tests

- \`test_proResEnums_rawValuesAreStableForAppStorage\` — pins rawValues for ProResVariant, ProResFrameRate, ProResAlphaHandling.
- \`test_proResToVectorConfig_defaultsMatchUIAppStorage\` — engine defaults match UI AppStorage defaults including the sentinel mapping.
- \`test_proResToVector_outputSizeWarning_firesAsExpected\` — verifies the engine warning helper fires for photorealistic tracing regardless of duration AND for long clips with cheap tracing.

## #381 progress

- [x] **#1 SubtitleTonemap** — PR #397 merged
- [x] **#5 SuiteCoreMetadataBackend** — PR #399 merged
- [x] **#6 AccurateRip submission** — PR #401 merged
- [x] **#2 RasterToVectorConfig** — PR #403 merged
- [x] **#3 ProResToVectorConfig** — this PR
- [ ] **#4 RenderFarmClient.Configuration** — last, **gated on #346 transport implementation**

After this lands, the only remaining #381 sub-task is the Render Farm tab, which is partly gated on engine work that hasn't fully landed (the transport adapters are scaffolded but not finished). Closing out the priority-1 and priority-2 sets means every engine subsystem from the #382 integration batch that has a stable UI shape now has UI bindings.

## Test plan

- [x] \`swift build\` clean.
- [x] 3 new tests pass.
- [ ] After merge: exercise both Vector Conversion and ProRes Vector in the running app, verify the embedded editor in ProRes mode renders identically to the stand-alone view's tracing sections, verify the output-size warning toggles when switching to photorealistic tracing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)