### PR TITLE
Add Render Farm settings tab (part of #381, addresses #406) — closes the #381 UI gap

### DIFF
--- a/Sources/MeedyaConverter/Views/RenderFarmSettingsTab.swift
+++ b/Sources/MeedyaConverter/Views/RenderFarmSettingsTab.swift
@@ -1,0 +1,432 @@
+// ============================================================================
+// MeedyaConverter — RenderFarmSettingsTab
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+//
+// SwiftUI surface for `RenderFarmClient.Configuration` + the manually-added
+// agent registry. Persists every user-facing preference via `@AppStorage`
+// under the `renderFarm.` namespace.
+//
+// Engine wiring caveat (#346 transport):
+//   The engine-side transport implementation in #346 has not fully landed —
+//   only the agent registry, configuration types, and InsecureTransportOverride
+//   token are stable. This tab therefore stores agents as a UserDefaults-
+//   backed JSON list rather than tying to a live `RenderFarmClient` instance.
+//   When #346 completes, the consumer reads these AppStorage keys to
+//   construct its Configuration + initial agent registry.
+//
+// Bonjour-discovered agents are NOT present yet — discovery is part of
+// the gated #346 work. The agent list shows the manual-entry workflow
+// alone; the empty state explains this.
+//
+// GitHub Issues: #346 engine (RenderFarmClient) / #380 (InsecureTransportOverride)
+//                / #381 / #406 UI.
+// ============================================================================
+
+import SwiftUI
+import ConverterEngine
+
+// MARK: - RenderFarmSettingsTab
+
+struct RenderFarmSettingsTab: View {
+
+    // -----------------------------------------------------------------
+    // MARK: - Persisted state
+    // -----------------------------------------------------------------
+
+    /// Whether the user has enabled insecure (plain HTTP) transports.
+    /// When `true`, the engine consumer constructs an
+    /// `InsecureTransportOverride` from `insecureAcknowledgement`.
+    @AppStorage("renderFarm.allowInsecureTransports") private var allowInsecureTransports: Bool = false
+
+    /// Required acknowledgement string passed to
+    /// `InsecureTransportOverride.developmentOnly(acknowledgement:)`.
+    /// Empty when `allowInsecureTransports` is false; required when it
+    /// is true.
+    @AppStorage("renderFarm.insecureAcknowledgement") private var insecureAcknowledgement: String = ""
+
+    /// Bonjour-discovery interval in seconds. Default matches
+    /// `RenderFarmClient.Configuration.init`'s default of 30s.
+    @AppStorage("renderFarm.discoveryIntervalSeconds") private var discoveryIntervalSeconds: Double = 30.0
+
+    /// Chunk upload size in MiB. Persisted as the user-facing value
+    /// (1/4/16/64) rather than raw bytes; converted to bytes when
+    /// the consumer constructs the engine Configuration.
+    @AppStorage("renderFarm.chunkSizeMiB") private var chunkSizeMiB: Int = 4
+
+    /// JSON-encoded `[RenderFarmAgentInfo]` for the manually-added agent
+    /// registry. Stored as `Data` rather than a String because the
+    /// AppStorage `Data` initialiser is more direct than wrapping JSON
+    /// in a String. An empty `Data()` decodes to `[]` via our binding.
+    @AppStorage("renderFarm.agentsJSON") private var agentsJSON: Data = Data()
+
+    // -----------------------------------------------------------------
+    // MARK: - View state
+    // -----------------------------------------------------------------
+
+    /// Controls the visibility of the Add-Agent modal sheet.
+    @State private var showAddAgentSheet: Bool = false
+
+    // -----------------------------------------------------------------
+    // MARK: - Computed bindings
+    // -----------------------------------------------------------------
+
+    /// Decodes / re-encodes the JSON-backed agent list. On any decode
+    /// failure (corrupt blob, future schema) we surface an empty list
+    /// so the UI never crashes — the user can re-add agents manually.
+    private var agents: [RenderFarmAgentInfo] {
+        guard !agentsJSON.isEmpty,
+              let decoded = try? JSONDecoder().decode(
+                [RenderFarmAgentInfo].self, from: agentsJSON)
+        else {
+            return []
+        }
+        return decoded
+    }
+
+    /// Available chunk-size choices, in MiB. Matches the four options
+    /// listed in the #381 acceptance criteria.
+    private static let chunkSizeChoicesMiB: [Int] = [1, 4, 16, 64]
+
+    // -----------------------------------------------------------------
+    // MARK: - Body
+    // -----------------------------------------------------------------
+
+    var body: some View {
+        Form {
+            insecureTransportSection
+            discoverySection
+            chunkSizeSection
+            agentsSection
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Render Farm")
+        .sheet(isPresented: $showAddAgentSheet) {
+            AddRenderFarmAgentSheet { newAgent in
+                appendAgent(newAgent)
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Sections
+    // -----------------------------------------------------------------
+
+    @ViewBuilder
+    private var insecureTransportSection: some View {
+        Section("Transport security") {
+            Toggle(
+                "Allow insecure transports (plain HTTP)",
+                isOn: $allowInsecureTransports
+            )
+            .accessibilityLabel(
+                "Allow plain HTTP submissions; not recommended"
+            )
+
+            if allowInsecureTransports {
+                // The engine's InsecureTransportOverride requires an
+                // acknowledgement string. We collect it here so the
+                // consumer can construct
+                //   .developmentOnly(acknowledgement: ...)
+                // without bouncing back to the UI.
+                TextField(
+                    "Acknowledgement",
+                    text: $insecureAcknowledgement,
+                    prompt: Text("e.g. 'local loopback, no real credentials'")
+                )
+                .accessibilityLabel(
+                    "Acknowledgement string recorded with every insecure "
+                    + "submission for audit purposes"
+                )
+
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text(
+                        "Plain HTTP exposes job payloads and credentials "
+                        + "to anyone on the network path. Enable only on "
+                        + "trusted loopback or isolated development networks."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var discoverySection: some View {
+        Section("Bonjour discovery") {
+            Stepper(
+                value: $discoveryIntervalSeconds,
+                in: 5...300,
+                step: 5
+            ) {
+                HStack {
+                    Text("Refresh interval")
+                    Spacer()
+                    Text("\(Int(discoveryIntervalSeconds)) s")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+            .accessibilityLabel(
+                "Bonjour discovery refresh interval in seconds"
+            )
+
+            Text(
+                "Bonjour discovery itself is not active yet (gated on "
+                + "issue #346). The interval will apply once the "
+                + "transport implementation lands."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var chunkSizeSection: some View {
+        Section("Source uploads") {
+            Picker("Chunk size", selection: $chunkSizeMiB) {
+                ForEach(Self.chunkSizeChoicesMiB, id: \.self) { size in
+                    Text("\(size) MiB").tag(size)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel(
+                "Chunk size for source uploads to render-farm agents"
+            )
+
+            Text(
+                "Smaller chunks resume faster after transient network "
+                + "failures; larger chunks are more efficient on stable "
+                + "links."
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var agentsSection: some View {
+        Section {
+            if agents.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("No agents configured.")
+                        .font(.subheadline)
+                    Text(
+                        "Bonjour-discovered agents will appear here once "
+                        + "the transport implementation in #346 lands. "
+                        + "In the meantime, you can add agents manually."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 2)
+            } else {
+                ForEach(agents) { agent in
+                    AgentRow(agent: agent) {
+                        removeAgent(id: agent.id)
+                    }
+                }
+            }
+
+            Button {
+                showAddAgentSheet = true
+            } label: {
+                Label("Add agent…", systemImage: "plus.circle")
+            }
+            .accessibilityLabel("Add a render-farm agent manually")
+        } header: {
+            HStack {
+                Text("Agents")
+                Spacer()
+                Text("\(agents.count) configured")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Agent registry mutations
+    // -----------------------------------------------------------------
+
+    /// Append a new agent to the JSON-backed registry. Persists via
+    /// the `agentsJSON` AppStorage key. Idempotent: if an agent with
+    /// the same `(host, port)` pair is already registered we replace
+    /// it rather than producing a duplicate, matching the engine's
+    /// `RenderFarmClient.register(agent:)` semantics.
+    private func appendAgent(_ agent: RenderFarmAgentInfo) {
+        var list = agents
+        list.removeAll { $0.host == agent.host && $0.port == agent.port }
+        list.append(agent)
+        persist(list)
+    }
+
+    /// Remove an agent by id. No-op if the id is not in the list.
+    private func removeAgent(id: UUID) {
+        let list = agents.filter { $0.id != id }
+        persist(list)
+    }
+
+    /// Encode and write the agent list back to AppStorage.
+    /// On encode failure we leave the previous value in place — the
+    /// alternative (silently clearing) would be far worse for the user.
+    private func persist(_ list: [RenderFarmAgentInfo]) {
+        guard let encoded = try? JSONEncoder().encode(list) else { return }
+        agentsJSON = encoded
+    }
+}
+
+// MARK: - AgentRow
+
+/// One row in the agents list. Renders the display name, endpoint,
+/// transport hint, and a discovered/manual badge. Tap the trash button
+/// to remove a manually-added agent; Bonjour-discovered rows hide the
+/// trash button because the engine owns their lifecycle.
+private struct AgentRow: View {
+
+    let agent: RenderFarmAgentInfo
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(agent.displayName).font(.subheadline.bold())
+                    Text(agent.discovered ? "Discovered" : "Manual")
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 1)
+                        .background(
+                            (agent.discovered ? Color.green : Color.blue)
+                                .opacity(0.15)
+                        )
+                        .foregroundStyle(agent.discovered ? .green : .blue)
+                        .clipShape(Capsule())
+                }
+                Text(agent.endpoint)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                if let sshUser = agent.sshUsername, !sshUser.isEmpty {
+                    Text("SSH user: \(sshUser)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            if !agent.discovered {
+                Button(role: .destructive, action: onRemove) {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("Remove agent \(agent.displayName)")
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// MARK: - AddRenderFarmAgentSheet
+
+/// Modal sheet for adding a render-farm agent by hand. Validates that
+/// at least a host is provided before allowing Save; everything else
+/// (port, SSH username, display name) falls back to reasonable defaults.
+private struct AddRenderFarmAgentSheet: View {
+
+    /// Callback invoked when the user taps Save. The parent appends
+    /// the agent to the JSON-backed registry.
+    let onSave: (RenderFarmAgentInfo) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var displayName: String = ""
+    @State private var host: String = ""
+    @State private var port: Int = 2229
+    @State private var sshUsername: String = ""
+
+    /// The Save button is disabled until the form has the minimum
+    /// information needed to construct a sensible `RenderFarmAgentInfo`.
+    private var canSave: Bool {
+        !host.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        Form {
+            Section("Agent") {
+                TextField(
+                    "Display name",
+                    text: $displayName,
+                    prompt: Text("e.g. studio-tower")
+                )
+                .accessibilityLabel("Display name for the agent")
+
+                TextField(
+                    "Host",
+                    text: $host,
+                    prompt: Text("hostname or IP")
+                )
+                .accessibilityLabel("Agent hostname or IP address")
+                .textContentType(.URL)
+
+                Stepper(
+                    value: $port,
+                    in: 1...65_535,
+                    step: 1
+                ) {
+                    HStack {
+                        Text("Port")
+                        Spacer()
+                        Text("\(port)")
+                            .foregroundStyle(.secondary)
+                            .monospacedDigit()
+                    }
+                }
+                .accessibilityLabel("Agent TCP port; default 2229")
+            }
+
+            Section("SSH (optional)") {
+                TextField(
+                    "Username",
+                    text: $sshUsername,
+                    prompt: Text("for transport = SSH")
+                )
+                .accessibilityLabel("SSH username used for SSH transport")
+                .textContentType(.username)
+
+                Text(
+                    "Required only when the agent is reached over SSH "
+                    + "tunnels. Leave empty for TLS or plain HTTP."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Add Agent")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") {
+                    let agent = RenderFarmAgentInfo(
+                        displayName: displayName.isEmpty
+                            ? host : displayName,
+                        host: host.trimmingCharacters(in: .whitespaces),
+                        port: port,
+                        sshUsername: sshUsername.isEmpty ? nil : sshUsername,
+                        discovered: false
+                    )
+                    onSave(agent)
+                    dismiss()
+                }
+                .disabled(!canSave)
+            }
+        }
+        .frame(minWidth: 380, minHeight: 320)
+    }
+}

--- a/Sources/MeedyaConverter/Views/SettingsView.swift
+++ b/Sources/MeedyaConverter/Views/SettingsView.swift
@@ -98,6 +98,10 @@ struct SettingsView: View {
                     MediaServerSettingsView()
                 }
 
+                Tab("Render Farm", systemImage: "network") {
+                    RenderFarmSettingsTab()
+                }
+
                 Tab("Analytics", systemImage: "chart.bar") {
                     AnalyticsSettingsView()
                 }

--- a/Tests/ConverterEngineTests/ConverterEngineTests.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests.swift
@@ -10532,6 +10532,75 @@ final class ConverterEngineTests: XCTestCase {
         }
     }
 
+    // MARK: - RenderFarm settings + agent registry (#346 / #381 / #406)
+
+    /// `RenderFarmTransport` rawValues are persisted as part of the
+    /// agent JSON blob. A rename on the engine side would silently
+    /// invalidate every user's persisted agent list — pin them.
+    func test_renderFarmTransport_rawValuesAreStableForAppStorage() {
+        XCTAssertEqual(RenderFarmTransport.ssh.rawValue, "ssh")
+        XCTAssertEqual(RenderFarmTransport.tls.rawValue, "tls")
+        XCTAssertEqual(RenderFarmTransport.plainHTTP.rawValue, "plainHTTP")
+    }
+
+    /// The `RenderFarmSettingsTab` agent list is stored as JSON-encoded
+    /// `[RenderFarmAgentInfo]` in an `@AppStorage` `Data` blob. Verify
+    /// the round-trip preserves every field — including the `id` and
+    /// `discovered` flags that drive UI behaviour (deletable vs not,
+    /// "Discovered"/"Manual" badge).
+    func test_renderFarmAgentInfo_jsonRoundTripPreservesAllFields() throws {
+        let original = RenderFarmAgentInfo(
+            displayName: "studio-tower",
+            host: "192.168.1.42",
+            port: 2229,
+            sshUsername: "render",
+            discovered: false,
+            architecture: "arm64",
+            hardwareEncoders: ["videotoolbox", "nvenc"]
+        )
+        let data = try JSONEncoder().encode([original])
+        let decoded = try JSONDecoder()
+            .decode([RenderFarmAgentInfo].self, from: data)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded[0].id, original.id)
+        XCTAssertEqual(decoded[0].displayName, "studio-tower")
+        XCTAssertEqual(decoded[0].host, "192.168.1.42")
+        XCTAssertEqual(decoded[0].port, 2229)
+        XCTAssertEqual(decoded[0].sshUsername, "render")
+        XCTAssertFalse(decoded[0].discovered)
+        XCTAssertEqual(decoded[0].architecture, "arm64")
+        XCTAssertEqual(decoded[0].hardwareEncoders, ["videotoolbox", "nvenc"])
+    }
+
+    /// The UI persists chunk size as user-facing MiB (1/4/16/64) and
+    /// converts to bytes when the consumer constructs the engine
+    /// Configuration. Verify the conversion + that the engine's
+    /// `defaultChunkSizeBytes` matches the UI default of 4 MiB so
+    /// the two sides agree out of the box.
+    func test_renderFarm_chunkSizeMiBToBytesConversion() {
+        XCTAssertEqual(UInt64(4) * 1024 * 1024,
+                       RenderFarmProtocol.defaultChunkSizeBytes,
+                       "UI default of 4 MiB must equal the engine's "
+                       + "RenderFarmProtocol.defaultChunkSizeBytes "
+                       + "so engine consumers reading the AppStorage "
+                       + "value behave identically when the user has "
+                       + "never touched the setting.")
+    }
+
+    /// Verifies the UI's "empty data → empty agent list" behaviour
+    /// against the actual JSON decoder. An empty `@AppStorage("renderFarm.agentsJSON")`
+    /// value is the user's initial state (no key written yet); the UI
+    /// surfaces this as the "No agents configured" empty state.
+    func test_renderFarmAgentInfo_emptyDataDecodesToEmptyList() {
+        let empty = Data()
+        let decoded = try? JSONDecoder()
+            .decode([RenderFarmAgentInfo].self, from: empty)
+        XCTAssertNil(decoded,
+                     "Empty Data should fail to decode as a JSON array; "
+                     + "the UI binding catches the failure and surfaces "
+                     + "an empty list.")
+    }
+
     // MARK: - ProResToVectorConfig + ProResVectorView (#377 / #381 / #404)
 
     /// `ProResVectorView` persists its enum fields as their rawValue


### PR DESCRIPTION
## Summary

Priority-3 sub-task of [#381](../issues/381), the final piece. **Closes out the #381 UI gap entirely** — all six engine subsystems from the #382 integration batch now have SwiftUI bindings. Tracking: [#406](../issues/406).

## Engine wiring caveat

The transport implementation in [#346](../issues/346) has not fully landed. Only the agent registry, configuration types, and \`InsecureTransportOverride\` token (from #380) are stable.

This tab therefore stores its preferences (including the agent list) as UserDefaults-backed AppStorage rather than tying to a live \`RenderFarmClient\` instance. When #346 completes, the consumer reads these AppStorage keys to construct its \`Configuration\` + initial agent registry. Bonjour discovery is not active yet; the empty-state copy in the agents section explains this in-line.

## Changes

### New tab in SettingsView

Slotted into the existing \`Services\` \`TabSection\` with SF Symbol \`network\`.

### New view: RenderFarmSettingsTab

[Sources/MeedyaConverter/Views/RenderFarmSettingsTab.swift](Sources/MeedyaConverter/Views/RenderFarmSettingsTab.swift) — Form with four sections:

| Section | Controls |
|---------|----------|
| Transport security | Toggle "Allow insecure transports" + required \`acknowledgement\` TextField + orange warning callout |
| Bonjour discovery | Refresh interval stepper, 5–300 s, step 5 |
| Source uploads | Chunk size segmented picker (1 / 4 / 16 / 64 MiB); UI persists MiB, consumer converts to bytes |
| Agents | Per-agent rows with Discovered/Manual badge, endpoint, optional SSH user, trash button (manual only); "Add agent…" button → sheet |

### Add-agent sheet

Private \`AddRenderFarmAgentSheet\` modal with display name, host, port (1–65535, default 2229), SSH username. Save disabled until at least a host is provided; falls back to using host as display name when none is supplied.

### Persistence

| AppStorage key | Type | Notes |
|---------------|------|-------|
| \`renderFarm.allowInsecureTransports\` | Bool | gates the acknowledgement field |
| \`renderFarm.insecureAcknowledgement\` | String | recorded for audit; required for \`.developmentOnly\` token |
| \`renderFarm.discoveryIntervalSeconds\` | Double | engine default of 30 s |
| \`renderFarm.chunkSizeMiB\` | Int | UI-facing MiB; conversion test below verifies 4 MiB = engine default |
| \`renderFarm.agentsJSON\` | Data | JSON-encoded \`[RenderFarmAgentInfo]\` |

Agent registry mutations are idempotent on \`(host, port)\` matching \`RenderFarmClient.register(agent:)\`.

### Tests

- \`test_renderFarmTransport_rawValuesAreStableForAppStorage\` — pins the three transport rawValues.
- \`test_renderFarmAgentInfo_jsonRoundTripPreservesAllFields\` — every field of \`RenderFarmAgentInfo\` survives encode/decode.
- \`test_renderFarm_chunkSizeMiBToBytesConversion\` — UI default of 4 MiB matches \`RenderFarmProtocol.defaultChunkSizeBytes\`.
- \`test_renderFarmAgentInfo_emptyDataDecodesToEmptyList\` — protects the UI's empty-data → empty-list fallback.

## #381 progress — FINAL

- [x] **#1 SubtitleTonemap** — PR #397 merged
- [x] **#5 SuiteCoreMetadataBackend** — PR #399 merged
- [x] **#6 AccurateRip submission** — PR #401 merged
- [x] **#2 RasterToVectorConfig** — PR #403 merged
- [x] **#3 ProResToVectorConfig** — PR #405 merged
- [x] **#4 RenderFarmClient.Configuration** — this PR

After this merges, **#381 can be closed**.

## Test plan

- [x] \`swift build\` clean.
- [x] 4 new tests pass; 17 RenderFarm-related tests all green.
- [ ] After merge: open Settings → Render Farm; toggle insecure transports; add a manual agent; verify it appears with the Manual badge; verify the trash button removes it; restart and verify persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)