### PR TITLE
Add SubtitleTonemapPipeline pre-processing helper (#369 follow-up)

### DIFF
--- a/Sources/ConverterEngine/Encoding/SubtitleTonemapPipeline.swift
+++ b/Sources/ConverterEngine/Encoding/SubtitleTonemapPipeline.swift
@@ -1,0 +1,287 @@
+// ============================================================================
+// MeedyaConverter — SubtitleTonemapPipeline
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+//
+// Pre-processing pipeline that, given an HDR source file and a per-profile
+// `SubtitleTonemapConfig`, extracts each candidate subtitle stream via
+// FFmpeg, runs `subtitle_tonemap` against the extracted file, and returns
+// the resulting tone-mapped files for the encoding pipeline to use.
+//
+// This file lives between `SubtitleTonemapWrapper` (which knows how to
+// invoke a single tone-map run) and `EncodingEngine` (which orchestrates
+// the encode). It is intentionally a standalone enum with static methods
+// rather than an extension of `EncodingEngine` so it can be unit-tested
+// without standing up an entire engine instance.
+//
+// Call-site integration in `EncodingEngine.encode(...)` is the follow-up
+// to this commit (see #369). The remaining piece of work is teaching
+// `FFmpegArgumentBuilder` to consume the returned `[TonemappedSubtitle]`
+// as additional `-i` inputs with the right `-map` overrides so the
+// tone-mapped subtitles replace the original ones in the output.
+//
+// GitHub Issues: #369 (engine binary + this pipeline) / #381 / #396
+// (profile field + UI binding shipped earlier in the cycle).
+// ============================================================================
+
+import Foundation
+
+// MARK: - SubtitleTonemapPipeline
+
+/// Namespace for the subtitle tone-mapping pre-processing pipeline.
+public enum SubtitleTonemapPipeline {
+
+    // -----------------------------------------------------------------
+    // MARK: - Result type
+    // -----------------------------------------------------------------
+
+    /// A single tone-mapped subtitle output, ready to substitute back
+    /// into the main encode.
+    public struct TonemappedSubtitle: Sendable, Hashable {
+
+        /// The stream index this subtitle occupied in the source file.
+        /// The encoding pipeline uses this to know which original
+        /// subtitle stream to suppress when remapping.
+        public let streamIndex: Int
+
+        /// The original codec name reported by the probe (e.g.
+        /// `"hdmv_pgs_subtitle"`, `"ass"`). Kept on the result so the
+        /// encoding pipeline can pick the right codec for the output
+        /// container when remapping.
+        public let codecName: String
+
+        /// The on-disk path of the tone-mapped subtitle file. Lives
+        /// inside the job's temp directory; the caller is responsible
+        /// for cleanup once the encode completes.
+        public let tonemappedFile: URL
+
+        public init(streamIndex: Int, codecName: String, tonemappedFile: URL) {
+            self.streamIndex = streamIndex
+            self.codecName = codecName
+            self.tonemappedFile = tonemappedFile
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Codec → extension mapping
+    // -----------------------------------------------------------------
+
+    /// File extension (and FFmpeg muxer name) for a given subtitle
+    /// codec, when `subtitle_tonemap` can operate on that codec.
+    ///
+    /// Returns `nil` for codecs that `subtitle_tonemap` does not yet
+    /// support — those streams will pass through unchanged. We
+    /// deliberately exclude `dvd_subtitle` / `vobsub` until the
+    /// pipeline learns to keep the companion `.idx` file alongside the
+    /// `.sub` payload; for now those streams are skipped rather than
+    /// risk producing a `.sub` that no demuxer can index.
+    public static func subtitleFileExtension(forCodec codec: String) -> String? {
+        switch codec.lowercased() {
+        case "hdmv_pgs_subtitle", "pgs":
+            // PGS / Blu-ray subtitles — the most common HDR subtitle
+            // carrier on modern remuxes.
+            return "sup"
+        case "ass", "ssa":
+            // SubStation Alpha — Anime / fan-sub formats, often
+            // shipped with HDR-coloured fonts.
+            return "ass"
+        default:
+            return nil
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Candidate-stream selection (pure)
+    // -----------------------------------------------------------------
+
+    /// Returns the subtitle streams in `sourceInfo` that should be
+    /// tone-mapped, given the profile's config and the availability of
+    /// the `subtitle_tonemap` binary.
+    ///
+    /// The function is *pure* — it does no I/O — so it can be unit-
+    /// tested cheaply. The four short-circuit cases (no config, no
+    /// HDR, wrapper unavailable, no supported codec) cover the
+    /// expected real-world distribution of inputs:
+    ///
+    ///   * SDR sources never trigger tone-mapping.
+    ///   * Sources with no subtitles trivially produce an empty list.
+    ///   * `subtitle_tonemap` is shipped in the tool bundle but may be
+    ///     missing on a developer machine that hasn't run
+    ///     `scripts/bundle-ffmpeg.sh` yet — silently degrade in that
+    ///     case rather than failing the encode.
+    ///
+    /// - Parameters:
+    ///   - sourceInfo: The probed source file.
+    ///   - config: The profile's `subtitleTonemap` setting — `nil`
+    ///     when the user has not opted in.
+    ///   - wrapperAvailable: Whether `SubtitleTonemapWrapper.isAvailable`
+    ///     returned `true` for this host.
+    /// - Returns: The candidate streams, preserving source order.
+    public static func candidateStreams(
+        in sourceInfo: MediaFile,
+        config: SubtitleTonemapConfig?,
+        wrapperAvailable: Bool
+    ) -> [MediaStream] {
+
+        // Short-circuit 1 — user did not opt in.
+        guard config != nil else { return [] }
+
+        // Short-circuit 2 — no point tone-mapping subtitles from an
+        // SDR source. The wrapper exists for the case where the video
+        // has HDR colours that the subtitle was authored against.
+        guard sourceInfo.hasHDR else { return [] }
+
+        // Short-circuit 3 — binary unavailable; the encoding pipeline
+        // will skip tone-mapping and the subtitles pass through.
+        guard wrapperAvailable else { return [] }
+
+        // Filter to supported codecs. Streams with codecs we cannot
+        // tone-map yet (DVD/VobSub, DVB subs, etc.) drop out here
+        // rather than reaching the subprocess stage.
+        return sourceInfo.subtitleStreams.filter { stream in
+            guard let codec = stream.codecName else { return false }
+            return subtitleFileExtension(forCodec: codec) != nil
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - FFmpeg argument builder for stream extraction
+    // -----------------------------------------------------------------
+
+    /// FFmpeg argument list that extracts a single subtitle stream
+    /// from `inputPath` to a standalone file at `outputPath` in the
+    /// muxer format that `subtitle_tonemap` expects.
+    ///
+    /// `-c:s copy` keeps the original codec payload bit-for-bit; the
+    /// `-f` muxer matches the extension produced by
+    /// `subtitleFileExtension(forCodec:)`.
+    public static func ffmpegExtractionArguments(
+        inputPath: String,
+        outputPath: String,
+        streamIndex: Int,
+        outputFormat: String
+    ) -> [String] {
+        [
+            "-y",
+            "-i", inputPath,
+            "-map", "0:\(streamIndex)",
+            "-c:s", "copy",
+            "-f", outputFormat,
+            outputPath,
+        ]
+    }
+
+    // -----------------------------------------------------------------
+    // MARK: - Full pipeline
+    // -----------------------------------------------------------------
+
+    /// Runs the full pre-processing pipeline: extract each candidate
+    /// subtitle stream via FFmpeg, then tone-map each via the supplied
+    /// wrapper. Per-stream failures are *logged but not fatal* — one
+    /// broken subtitle should not cause an otherwise-good encode to
+    /// fail.
+    ///
+    /// The `runFFmpeg` closure is dependency-injected so the call
+    /// site (`EncodingEngine.encode`) can route extraction through its
+    /// existing `runFFmpegPass` helper (which already understands
+    /// progress reporting, signal handling, and stderr capture).
+    /// Tests pass an in-memory stub.
+    ///
+    /// - Parameters:
+    ///   - source: The source media URL.
+    ///   - sourceInfo: The probed source metadata.
+    ///   - config: The profile's tone-map config. `nil` short-circuits
+    ///     the whole pipeline and returns an empty result.
+    ///   - wrapper: The `SubtitleTonemapWrapper` to invoke. Tests can
+    ///     subclass / mock; production passes the engine's instance.
+    ///   - tempDir: A writable directory the pipeline uses for both
+    ///     the extracted and tone-mapped intermediates. The caller
+    ///     owns the directory and its lifecycle.
+    ///   - runFFmpeg: Dependency-injected FFmpeg invocation.
+    /// - Returns: One `TonemappedSubtitle` per successfully processed
+    ///   stream. May be shorter than the candidate-stream list if
+    ///   individual streams hit errors.
+    public static func run(
+        source: URL,
+        sourceInfo: MediaFile,
+        config: SubtitleTonemapConfig?,
+        wrapper: SubtitleTonemapWrapper,
+        tempDir: URL,
+        runFFmpeg: @Sendable (_ args: [String]) async throws -> Void
+    ) async -> [TonemappedSubtitle] {
+
+        let candidates = candidateStreams(
+            in: sourceInfo,
+            config: config,
+            wrapperAvailable: wrapper.isAvailable
+        )
+        guard let config else { return [] }
+        if candidates.isEmpty { return [] }
+
+        var results: [TonemappedSubtitle] = []
+        results.reserveCapacity(candidates.count)
+
+        for stream in candidates {
+            guard let codec = stream.codecName,
+                  let ext = subtitleFileExtension(forCodec: codec)
+            else { continue }
+
+            let extractedURL = tempDir.appendingPathComponent(
+                "subtitle-\(stream.streamIndex)-source.\(ext)"
+            )
+            let tonemappedURL = tempDir.appendingPathComponent(
+                "subtitle-\(stream.streamIndex)-tonemapped.\(ext)"
+            )
+
+            // 1. Extract via FFmpeg. A failure here means the stream
+            //    cannot be processed — log and move on.
+            do {
+                try await runFFmpeg(
+                    ffmpegExtractionArguments(
+                        inputPath: source.path,
+                        outputPath: extractedURL.path,
+                        streamIndex: stream.streamIndex,
+                        outputFormat: ext
+                    )
+                )
+            } catch {
+                print("Warning: subtitle stream \(stream.streamIndex) "
+                      + "extraction failed (#369 pipeline): "
+                      + "\(error.localizedDescription)")
+                continue
+            }
+
+            // 2. Tone-map via the wrapper.
+            do {
+                try await wrapper.toneMap(
+                    inputPath: extractedURL.path,
+                    outputPath: tonemappedURL.path,
+                    config: config
+                )
+            } catch {
+                print("Warning: subtitle_tonemap failed for stream "
+                      + "\(stream.streamIndex) (#369 pipeline): "
+                      + "\(error.localizedDescription)")
+                // Clean up the extracted file before continuing.
+                try? FileManager.default.removeItem(at: extractedURL)
+                continue
+            }
+
+            // 3. Record the success. We deliberately leave the
+            //    extracted intermediate in place — it lives in the
+            //    job's temp dir, which `TempFileManager.cleanupJob`
+            //    will remove wholesale after the encode finishes.
+            results.append(
+                TonemappedSubtitle(
+                    streamIndex: stream.streamIndex,
+                    codecName: codec,
+                    tonemappedFile: tonemappedURL
+                )
+            )
+        }
+
+        return results
+    }
+}

--- a/Tests/ConverterEngineTests/ConverterEngineTests.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests.swift
@@ -10828,6 +10828,146 @@ final class ConverterEngineTests: XCTestCase {
         XCTAssertNil(SuiteCoreMetadataBackend(rawValue: ""))
     }
 
+    // MARK: - SubtitleTonemapPipeline (#369 follow-up)
+
+    /// Codec → extension mapping is the entry-point of the whole
+    /// pipeline; pin the supported codecs explicitly so a future
+    /// engine-side change can't silently break the call site.
+    func test_subtitleTonemapPipeline_codecToExtensionMapping() {
+        // Supported codecs.
+        XCTAssertEqual(
+            SubtitleTonemapPipeline.subtitleFileExtension(forCodec: "hdmv_pgs_subtitle"),
+            "sup"
+        )
+        XCTAssertEqual(
+            SubtitleTonemapPipeline.subtitleFileExtension(forCodec: "pgs"),
+            "sup"
+        )
+        XCTAssertEqual(
+            SubtitleTonemapPipeline.subtitleFileExtension(forCodec: "ass"),
+            "ass"
+        )
+        XCTAssertEqual(
+            SubtitleTonemapPipeline.subtitleFileExtension(forCodec: "ssa"),
+            "ass"
+        )
+        // Case-insensitive lookup.
+        XCTAssertEqual(
+            SubtitleTonemapPipeline.subtitleFileExtension(forCodec: "HDMV_PGS_SUBTITLE"),
+            "sup"
+        )
+        // Deferred / unsupported codecs return nil so the pipeline
+        // skips them rather than producing garbage output.
+        XCTAssertNil(SubtitleTonemapPipeline.subtitleFileExtension(forCodec: "dvd_subtitle"))
+        XCTAssertNil(SubtitleTonemapPipeline.subtitleFileExtension(forCodec: "vobsub"))
+        XCTAssertNil(SubtitleTonemapPipeline.subtitleFileExtension(forCodec: "dvb_subtitle"))
+        XCTAssertNil(SubtitleTonemapPipeline.subtitleFileExtension(forCodec: "srt"))
+    }
+
+    /// Candidate selection: each short-circuit must produce an empty
+    /// list. These are the four early-return cases that protect SDR
+    /// encodes from accidentally invoking a binary they don't need.
+    func test_subtitleTonemapPipeline_candidateStreams_shortCircuits() {
+        let url = URL(fileURLWithPath: "/tmp/test.mkv")
+        let pgsSub = MediaStream(
+            streamIndex: 2,
+            streamType: .subtitle,
+            codecName: "hdmv_pgs_subtitle"
+        )
+        let hdrVideo = MediaStream(
+            streamIndex: 0,
+            streamType: .video,
+            hdrFormats: [.hdr10]
+        )
+        let file = MediaFile(
+            fileURL: url,
+            streams: [hdrVideo, pgsSub]
+        )
+        let cfg = SubtitleTonemapConfig()
+
+        // 1. nil config → user has not opted in.
+        XCTAssertEqual(
+            SubtitleTonemapPipeline.candidateStreams(
+                in: file, config: nil, wrapperAvailable: true
+            ).count,
+            0
+        )
+
+        // 2. SDR source → nothing to tone-map against.
+        let sdrVideo = MediaStream(streamIndex: 0, streamType: .video)
+        let sdrFile = MediaFile(fileURL: url, streams: [sdrVideo, pgsSub])
+        XCTAssertEqual(
+            SubtitleTonemapPipeline.candidateStreams(
+                in: sdrFile, config: cfg, wrapperAvailable: true
+            ).count,
+            0
+        )
+
+        // 3. Wrapper binary unavailable → skip rather than fail.
+        XCTAssertEqual(
+            SubtitleTonemapPipeline.candidateStreams(
+                in: file, config: cfg, wrapperAvailable: false
+            ).count,
+            0
+        )
+
+        // 4. All preconditions met → returns the candidate.
+        let candidates = SubtitleTonemapPipeline.candidateStreams(
+            in: file, config: cfg, wrapperAvailable: true
+        )
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates.first?.streamIndex, 2)
+    }
+
+    /// Codec filtering: a file with a mix of supported and unsupported
+    /// subtitle codecs should yield only the supported ones, preserving
+    /// source order. Protects the assumption that the pipeline emits a
+    /// 1:1 correspondence with the actually-tonemappable streams.
+    func test_subtitleTonemapPipeline_candidateStreams_filtersByCodec() {
+        let url = URL(fileURLWithPath: "/tmp/test.mkv")
+        let hdrVideo = MediaStream(
+            streamIndex: 0,
+            streamType: .video,
+            hdrFormats: [.hdr10]
+        )
+        let streams: [MediaStream] = [
+            hdrVideo,
+            MediaStream(streamIndex: 1, streamType: .subtitle, codecName: "srt"),       // unsupported (text)
+            MediaStream(streamIndex: 2, streamType: .subtitle, codecName: "hdmv_pgs_subtitle"), // supported
+            MediaStream(streamIndex: 3, streamType: .subtitle, codecName: "dvd_subtitle"),       // deferred
+            MediaStream(streamIndex: 4, streamType: .subtitle, codecName: "ass"),                // supported
+        ]
+        let file = MediaFile(fileURL: url, streams: streams)
+        let cfg = SubtitleTonemapConfig()
+
+        let candidates = SubtitleTonemapPipeline.candidateStreams(
+            in: file, config: cfg, wrapperAvailable: true
+        )
+        XCTAssertEqual(candidates.map(\.streamIndex), [2, 4],
+                       "Only supported codecs should pass, in source order")
+    }
+
+    /// FFmpeg extraction args: the pipeline must emit the exact six-
+    /// argument form that pairs with `subtitle_tonemap`'s expected
+    /// input layout. A drift here would produce malformed extraction
+    /// commands that fail at runtime.
+    func test_subtitleTonemapPipeline_extractionArgumentsAreStable() {
+        let args = SubtitleTonemapPipeline.ffmpegExtractionArguments(
+            inputPath: "/tmp/source.mkv",
+            outputPath: "/tmp/extracted.sup",
+            streamIndex: 2,
+            outputFormat: "sup"
+        )
+        XCTAssertEqual(args, [
+            "-y",
+            "-i", "/tmp/source.mkv",
+            "-map", "0:2",
+            "-c:s", "copy",
+            "-f", "sup",
+            "/tmp/extracted.sup",
+        ])
+    }
+
     // MARK: - SubtitleTonemapWrapper (#369)
 
     /// Pins the SubtitleTonemapConfig default-initialised values against


### PR DESCRIPTION
## Summary

Closes the consumer-wiring gap between \`SubtitleTonemapWrapper\` (shipped in PR #382) and the encoding pipeline. The wrapper knows how to tone-map a single subtitle file; the new \`SubtitleTonemapPipeline\` knows how to iterate the subtitle streams in a probed source, pick the candidates, run extraction + tone-mapping, and return the results for the encoding pipeline to use.

Tracking: comment on (closed) #369, plus new follow-up issue [#409](../issues/409) for the EncodingEngine.encode() call-site wiring.

## What's in the PR

### \`Sources/ConverterEngine/Encoding/SubtitleTonemapPipeline.swift\` (new)

A standalone enum with three layered public surfaces:

| Surface | Role |
|---------|------|
| \`subtitleFileExtension(forCodec:)\` | Pure mapping: codec name → file extension + FFmpeg muxer. Handles PGS (\`hdmv_pgs_subtitle\` → \`.sup\`) and SubStation Alpha (\`ass\`/\`ssa\` → \`.ass\`). DVD/VobSub deferred — needs \`.idx\` companion handling. |
| \`candidateStreams(in:config:wrapperAvailable:)\` | Pure function that filters the source's subtitle streams down to the candidates. Four short-circuit returns (nil config, SDR source, wrapper unavailable, unsupported codec). |
| \`run(source:sourceInfo:config:wrapper:tempDir:runFFmpeg:)\` | Async driver. Extracts each candidate via FFmpeg, then tone-maps via the wrapper. Per-stream failures are non-fatal — logged but the encode continues. \`runFFmpeg\` is dependency-injected so the call site can route through its own progress-aware runner. |

Returns \`[TonemappedSubtitle]\`: \`(streamIndex, codecName, tonemappedFile)\` tuples ready for the caller to substitute back into the main encode.

### Tests (4 new, all passing locally)

- \`test_subtitleTonemapPipeline_codecToExtensionMapping\` — pins the supported codecs + the deferred exclusions.
- \`test_subtitleTonemapPipeline_candidateStreams_shortCircuits\` — every early-return path verified.
- \`test_subtitleTonemapPipeline_candidateStreams_filtersByCodec\` — mixed-codec stream list yields exactly the supported subset in source order.
- \`test_subtitleTonemapPipeline_extractionArgumentsAreStable\` — pins the exact six-argument FFmpeg invocation form.

Full async \`run(...)\` integration is not tested here — it depends on FFmpeg + subtitle_tonemap binaries which may be absent on CI runners. Integration coverage will land alongside the call-site wiring in #409.

## What's deliberately NOT in this PR

\`EncodingEngine.encode(...)\` still does not invoke the pipeline. The remaining work to wire it in — teaching \`FFmpegArgumentBuilder\` to accept per-subtitle-stream input replacements and emit the right \`-map\` overrides — is tracked in #409 as a discrete follow-up. The pipeline is fully usable in isolation today, e.g. the CLI \`meedya-convert\` could call it directly.

## Test plan

- [x] \`swift build\` clean. Only pre-existing warnings in \`ResourceMonitorView.swift\` (unrelated).
- [x] 4 new tests pass; full suite green.
- [ ] After merge: verify the existing closed #369 comment + new #409 link to this PR correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)