### PR TITLE
Cache SPM dependencies in codeql.yml (fixes the 75-min CodeQL cancellations)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,29 @@ jobs:
       - name: Verify Swift version
         run: swift --version
 
-      # Step 3: Initialize CodeQL for the specified language
+      # Step 3: Cache SPM dependencies
+      #
+      # Without this, every CodeQL run rebuilds all SPM dependencies from
+      # scratch — the project is large enough that an unlucky cold runner
+      # can spend the entire 75-minute job budget on `swift build` alone
+      # and never reach the analysis step. Matching the cache key shape
+      # used by build.yml and release.yml so the three workflows share
+      # cache entries when Package.resolved is unchanged.
+      #
+      # Restore-keys is a prefix fallback: if no exact match for the
+      # current Package.resolved exists, take whatever recent macOS SPM
+      # cache is available. Partial reuse beats no reuse by a wide
+      # margin; SPM will rebuild only the affected dependencies.
+      - name: Cache SPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-codeql-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-codeql-
+            ${{ runner.os }}-spm-
+
+      # Step 4: Initialize CodeQL for the specified language
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
@@ -69,11 +91,11 @@ jobs:
           # Use extended security queries for comprehensive analysis
           queries: security-extended
 
-      # Step 4: Build the project (CodeQL needs to observe the build)
+      # Step 5: Build the project (CodeQL needs to observe the build)
       - name: Build for CodeQL analysis
         run: swift build
 
-      # Step 5: Run CodeQL analysis
+      # Step 6: Run CodeQL analysis
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:


### PR DESCRIPTION
## Summary

PR #410's CodeQL run hit the 75-minute cap **even after PR #408 bumped it from 45 → 75 min**. Same code completed CodeQL in 26 minutes on main right after merge. The 3× variance was \`swift build\` rebuilding from cold every time because \`codeql.yml\` had no SPM cache (unlike build.yml + release.yml).

## Diagnosis (per-step timings)

| Run | Build for CodeQL analysis | Total | Outcome |
|-----|---------------------------|-------|---------|
| Main, post-#410 merge (id 26129098306) | 1450 s ≈ 24 min | ≈ 26 min | ✅ success |
| PR #410 (id 26124433339) | 4499 s ≈ 75 min | hit cap | ❌ cancelled |

Same Swift, same runner image, same code. The only difference: cache state.

## Fix

Add \`actions/cache@v4\` step in \`codeql.yml\` between "Verify Swift version" and "Initialize CodeQL". Key matches the shape used by build.yml and release.yml so the three workflows can share cache entries when \`Package.resolved\` is unchanged. Restore-keys provides a graceful prefix fallback: partial reuse (SPM rebuilds only affected dependencies) is much faster than cold start.

\`\`\`yaml
- name: Cache SPM dependencies
  uses: actions/cache@v4
  with:
    path: .build
    key: \${{ runner.os }}-spm-codeql-\${{ hashFiles('Package.resolved') }}
    restore-keys: |
      \${{ runner.os }}-spm-codeql-
      \${{ runner.os }}-spm-
\`\`\`

## Expected effect

- **Cache hit on Package.resolved**: build time should drop to ~5-10 minutes
- **Near-match (prefix fallback)**: ~15-20 minutes (SPM rebuilds only affected dependencies)
- **Cold start** (e.g., first run after cache eviction): same as today, but now the next run benefits

Either way, the 75-minute cap stops being a regular issue. Once a few warm-cache runs confirm the new ceiling, we can revisit whether to tighten \`timeout-minutes\` back down from 75 to ~45.

## Verification

The most useful evidence is this PR's own CodeQL run — first push, no cache hit, but the second push (or any future PR after this lands on main) should show a clear drop. I'll flag the timings in a follow-up comment after the run completes.

## Test plan

- [x] YAML parses cleanly (\`python3 -c "import yaml; yaml.safe_load(...)"\`).
- [x] Pattern matches the cache step already in use in build.yml and release.yml.
- [ ] First post-merge CodeQL run on main should hit the new \`spm-codeql-\` cache key; subsequent runs should benefit measurably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)