### PR TITLE
Wire SubtitleTonemapPipeline into EncodingEngine (closes #409, #369 complete)

### DIFF
--- a/Sources/ConverterEngine/Encoding/EncodingEngine.swift
+++ b/Sources/ConverterEngine/Encoding/EncodingEngine.swift
@@ -91,6 +91,11 @@ public final class EncodingEngine: @unchecked Sendable {
     /// The hlg-tools wrapper for PQ → HLG conversion.
     public let hlgTools: HlgToolsWrapper
 
+    /// The subtitle_tonemap wrapper for HDR subtitle colour correction
+    /// (Issues #369 / #409). Used by the pre-processing pipeline below
+    /// when a profile carries a non-nil `subtitleTonemap` config.
+    public let subtitleTonemapper: SubtitleTonemapWrapper
+
     /// Cached FFmpeg binary info (populated after configure()).
     public private(set) var ffmpegInfo: FFmpegBinaryInfo?
 
@@ -126,6 +131,7 @@ public final class EncodingEngine: @unchecked Sendable {
         self.hardwareDetector = HardwareEncoderDetector()
         self.doviTool = DoviToolWrapper()
         self.hlgTools = HlgToolsWrapper()
+        self.subtitleTonemapper = SubtitleTonemapWrapper()
     }
 
     // MARK: - Configuration
@@ -330,6 +336,65 @@ public final class EncodingEngine: @unchecked Sendable {
                    let minLum = cp.masteringDisplayMinLuminance {
                     enrichedJob.hdrMasteringDisplay =
                         "G(13250,34500)B(7500,3000)R(34000,16000)WP(15635,16450)L(\(maxLum * 10000),\(minLum))"
+                }
+            }
+        }
+
+        // -----------------------------------------------------------
+        // Subtitle tone-mapping pre-processing (Issues #369 / #409)
+        // -----------------------------------------------------------
+        //
+        // When the profile opts in (profile.subtitleTonemap != nil), the
+        // source is HDR, AND subtitles are passing through, extract each
+        // supported HDR subtitle stream and run subtitle_tonemap on it.
+        // The pipeline returns one entry per successfully-processed stream;
+        // we build a full per-stream action list that:
+        //
+        //   * .replaceWith(tonemappedFile) for every successfully-processed
+        //     stream  → the encoder picks the SDR-coloured version from a
+        //     separate -i input
+        //   * .passthrough for every other subtitle stream  → unchanged
+        //     stream-by-stream copy from the source
+        //
+        // Including passthrough entries for non-tonemapped streams is
+        // important: once subtitleStreamActions is non-empty the builder
+        // uses it EXCLUSIVELY, so omitting a stream here would silently
+        // drop it from the output. The pipeline.run() helper returns
+        // empty (no-op) when subtitleTonemap is nil, the source is SDR,
+        // or no supported subtitle codec is present — leaving the
+        // legacy subtitlePassthrough behaviour intact.
+        if let sourceInfo,
+           job.profile.subtitlePassthrough,
+           job.profile.subtitleTonemap != nil {
+            let tonemapped = await SubtitleTonemapPipeline.run(
+                source: job.inputURL,
+                sourceInfo: sourceInfo,
+                config: job.profile.subtitleTonemap,
+                wrapper: subtitleTonemapper,
+                tempDir: tempDir,
+                runFFmpeg: { args in
+                    try await self.runFFmpegPass(
+                        ffmpegPath: ffmpegPath,
+                        arguments: args,
+                        pass: nil,
+                        multipassLogPath: nil,
+                        sourceDuration: sourceDuration,
+                        onProgress: { _ in } // Silent extraction
+                    )
+                }
+            )
+            if !tonemapped.isEmpty {
+                let resultByIndex = Dictionary(
+                    uniqueKeysWithValues: tonemapped.map { ($0.streamIndex, $0) }
+                )
+                enrichedJob.subtitleStreamActions = sourceInfo.subtitleStreams.map { stream in
+                    if let result = resultByIndex[stream.streamIndex] {
+                        return .init(
+                            streamIndex: stream.streamIndex,
+                            action: .replaceWith(result.tonemappedFile)
+                        )
+                    }
+                    return .init(streamIndex: stream.streamIndex, action: .passthrough)
                 }
             }
         }

--- a/Sources/ConverterEngine/Encoding/EncodingJob.swift
+++ b/Sources/ConverterEngine/Encoding/EncodingJob.swift
@@ -111,6 +111,16 @@ public struct EncodingJobConfig: Identifiable, Codable, Sendable {
     /// When `.pq`, PQ/HDR10 colour metadata is applied.
     public var hdrTransferFunction: HDRTransferFunction?
 
+    /// Per-source-stream subtitle handling (Issue #409). Populated by
+    /// `EncodingEngine.encode(...)` from the result of
+    /// `SubtitleTonemapPipeline.run(...)` so HDR subtitle tone-mapping
+    /// (#369) actually reaches the output.
+    ///
+    /// Empty by default — when empty, the FFmpegArgumentBuilder uses
+    /// its legacy `subtitlePassthrough`/`subtitleStreamIndex` behaviour
+    /// and no existing call site is affected.
+    public var subtitleStreamActions: [FFmpegArgumentBuilder.SubtitleStreamActionEntry] = []
+
     /// Timestamp when this job was created.
     public var createdAt: Date
 
@@ -159,6 +169,14 @@ public struct EncodingJobConfig: Identifiable, Codable, Sendable {
         builder.audioStreamIndex = audioStreamIndex
         builder.subtitleStreamIndex = subtitleStreamIndex
         builder.mapAllStreams = mapAllStreams
+
+        // Per-source-stream subtitle actions (Issue #409). When
+        // non-empty, takes precedence over the legacy
+        // subtitlePassthrough/subtitleStreamIndex pair (see
+        // FFmpegArgumentBuilder.buildStreamMapping for the override
+        // logic). Populated by EncodingEngine.encode(...) from the
+        // SubtitleTonemapPipeline result.
+        builder.subtitleStreamActions = subtitleStreamActions
 
         // Apply metadata
         builder.metadata = outputMetadata

--- a/Sources/ConverterEngine/FFmpeg/FFmpegArgumentBuilder.swift
+++ b/Sources/ConverterEngine/FFmpeg/FFmpegArgumentBuilder.swift
@@ -194,7 +194,7 @@ public struct FFmpegArgumentBuilder: Sendable {
     /// `SubtitleTonemapPipeline.run`) has produced a transformed
     /// version of that stream and the encoder should pull it from a
     /// separate file. `.drop` removes the stream from the output.
-    public enum SubtitleStreamAction: Sendable, Equatable {
+    public enum SubtitleStreamAction: Sendable, Equatable, Codable {
         /// Copy this stream straight through from input 0 (the source).
         case passthrough
         /// Substitute this stream with the contents of `URL`, which is
@@ -204,7 +204,23 @@ public struct FFmpegArgumentBuilder: Sendable {
         case drop
     }
 
-    /// Ordered list of `(sourceStreamIndex, action)` pairs that drives
+    /// One entry in `subtitleStreamActions`. A small struct rather than
+    /// a tuple so the surrounding `EncodingJobConfig` (which is
+    /// `Codable`) can synthesise its own Codable conformance — tuples
+    /// have no Codable support.
+    public struct SubtitleStreamActionEntry: Sendable, Equatable, Codable {
+        /// The source subtitle stream index this action applies to.
+        public var streamIndex: Int
+        /// What the encoder should do with that stream.
+        public var action: SubtitleStreamAction
+
+        public init(streamIndex: Int, action: SubtitleStreamAction) {
+            self.streamIndex = streamIndex
+            self.action = action
+        }
+    }
+
+    /// Ordered list of `(sourceStreamIndex, action)` entries that drives
     /// subtitle mapping when non-empty. When this is set, the existing
     /// `subtitlePassthrough` / `subtitleStreamIndex` fields are
     /// IGNORED in favour of this explicit per-stream layout.
@@ -221,7 +237,7 @@ public struct FFmpegArgumentBuilder: Sendable {
     /// `EncodingEngine.encode(...)` populates this from the result of
     /// `SubtitleTonemapPipeline.run(...)` so HDR subtitle tone-mapping
     /// (#369) actually reaches the output.
-    public var subtitleStreamActions: [(streamIndex: Int, action: SubtitleStreamAction)] = []
+    public var subtitleStreamActions: [SubtitleStreamActionEntry] = []
 
     // MARK: - Per-Stream Audio Settings (Phase 3.2 / Issue #38)
 

--- a/Sources/ConverterEngine/FFmpeg/FFmpegArgumentBuilder.swift
+++ b/Sources/ConverterEngine/FFmpeg/FFmpegArgumentBuilder.swift
@@ -184,6 +184,45 @@ public struct FFmpegArgumentBuilder: Sendable {
     /// Whether to disable all subtitle streams in output.
     public var disableSubtitles: Bool = false
 
+    // MARK: - Per-stream subtitle actions (Issue #409)
+
+    /// Per-source-stream subtitle handling action.
+    ///
+    /// Defaults to `.passthrough` when the source's subtitle stream
+    /// should be copied as-is from input 0. `.replaceWith(URL)` is set
+    /// when an upstream pre-processing step (currently
+    /// `SubtitleTonemapPipeline.run`) has produced a transformed
+    /// version of that stream and the encoder should pull it from a
+    /// separate file. `.drop` removes the stream from the output.
+    public enum SubtitleStreamAction: Sendable, Equatable {
+        /// Copy this stream straight through from input 0 (the source).
+        case passthrough
+        /// Substitute this stream with the contents of `URL`, which is
+        /// added to the FFmpeg invocation as an additional input.
+        case replaceWith(URL)
+        /// Suppress this stream entirely.
+        case drop
+    }
+
+    /// Ordered list of `(sourceStreamIndex, action)` pairs that drives
+    /// subtitle mapping when non-empty. When this is set, the existing
+    /// `subtitlePassthrough` / `subtitleStreamIndex` fields are
+    /// IGNORED in favour of this explicit per-stream layout.
+    ///
+    /// The order of entries is preserved in the resulting `-map`
+    /// arguments. Replacement URLs are appended to the FFmpeg input
+    /// list in encounter order, AFTER `inputURL` and
+    /// `additionalInputs` already configured by the caller — so a
+    /// replacement's FFmpeg input index is `1 + additionalInputs.count
+    /// + replacementOrdinal`.
+    ///
+    /// Empty by default; the existing builder behaviour is unchanged
+    /// for callers that do not opt in. The encoding pipeline at
+    /// `EncodingEngine.encode(...)` populates this from the result of
+    /// `SubtitleTonemapPipeline.run(...)` so HDR subtitle tone-mapping
+    /// (#369) actually reaches the output.
+    public var subtitleStreamActions: [(streamIndex: Int, action: SubtitleStreamAction)] = []
+
     // MARK: - Per-Stream Audio Settings (Phase 3.2 / Issue #38)
 
     /// Per-stream audio codec overrides, keyed by output audio stream index.
@@ -309,6 +348,15 @@ public struct FFmpegArgumentBuilder: Sendable {
 
         for additionalInput in additionalInputs {
             args.append(contentsOf: ["-i", additionalInput.path])
+        }
+
+        // --- Subtitle replacement inputs (Issue #409) ---
+        // Each .replaceWith(url) action contributes one additional `-i`
+        // input here, in encounter order. The mapping code in
+        // `buildStreamMapping()` references these by their resulting
+        // input index (1 + additionalInputs.count + replacementOrdinal).
+        for replacement in subtitleReplacementInputs {
+            args.append(contentsOf: ["-i", replacement.path])
         }
 
         // --- Stream mapping ---
@@ -481,7 +529,14 @@ public struct FFmpegArgumentBuilder: Sendable {
                 args.append(contentsOf: ["-map", "0:a?"])
             }
 
-            if subtitlePassthrough {
+            // --- Subtitle mapping ---
+            // When `subtitleStreamActions` is non-empty it takes
+            // precedence over `subtitlePassthrough` / `subtitleStreamIndex`
+            // and drives subtitle mapping explicitly (Issue #409).
+            // Otherwise fall back to the legacy passthrough behaviour.
+            if !subtitleStreamActions.isEmpty {
+                args.append(contentsOf: buildSubtitleStreamActionMapping())
+            } else if subtitlePassthrough {
                 if let si = subtitleStreamIndex {
                     args.append(contentsOf: ["-map", "0:s:\(si)"])
                 } else {
@@ -491,6 +546,44 @@ public struct FFmpegArgumentBuilder: Sendable {
         }
 
         return args
+    }
+
+    /// Map subtitle streams according to the explicit per-stream action
+    /// layout in `subtitleStreamActions`. Replacement inputs are
+    /// referenced by the input index they were declared at in `build()`.
+    private func buildSubtitleStreamActionMapping() -> [String] {
+        // The first replacement input's FFmpeg `-i` index is one past
+        // `inputURL` (index 0) plus the caller-provided
+        // `additionalInputs`. Subsequent replacements consume the next
+        // index in source-stream-action order.
+        let firstReplacementInputIndex = 1 + additionalInputs.count
+        var nextReplacementInput = firstReplacementInputIndex
+        var args: [String] = []
+        for action in subtitleStreamActions {
+            switch action.action {
+            case .passthrough:
+                args.append(contentsOf: ["-map", "0:s:\(action.streamIndex)"])
+            case .replaceWith:
+                // Each replacement file is itself a standalone subtitle
+                // file (one stream, index 0 within that input).
+                args.append(contentsOf: ["-map", "\(nextReplacementInput):s:0"])
+                nextReplacementInput += 1
+            case .drop:
+                continue
+            }
+        }
+        return args
+    }
+
+    /// The ordered URLs of subtitle replacements declared in
+    /// `subtitleStreamActions`. Used by `build()` to emit the matching
+    /// `-i` arguments and by `buildSubtitleStreamActionMapping()` to
+    /// reason about input indices.
+    private var subtitleReplacementInputs: [URL] {
+        subtitleStreamActions.compactMap { entry in
+            if case .replaceWith(let url) = entry.action { return url }
+            return nil
+        }
     }
 
     /// Build video codec and quality arguments.

--- a/Tests/ConverterEngineTests/ConverterEngineTests.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests.swift
@@ -309,8 +309,8 @@ final class ConverterEngineTests: XCTestCase {
         builder.inputURL = URL(fileURLWithPath: "/tmp/in.mkv")
         builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
         builder.subtitleStreamActions = [
-            (streamIndex: 2, action: .passthrough),
-            (streamIndex: 3, action: .passthrough),
+            .init(streamIndex: 2, action: .passthrough),
+            .init(streamIndex: 3, action: .passthrough),
         ]
 
         let args = builder.build()
@@ -332,7 +332,7 @@ final class ConverterEngineTests: XCTestCase {
         builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
         let tonemapped = URL(fileURLWithPath: "/tmp/sub2.sup")
         builder.subtitleStreamActions = [
-            (streamIndex: 2, action: .replaceWith(tonemapped)),
+            .init(streamIndex: 2, action: .replaceWith(tonemapped)),
         ]
 
         let args = builder.build()
@@ -357,10 +357,10 @@ final class ConverterEngineTests: XCTestCase {
         let englishTonemapped = URL(fileURLWithPath: "/tmp/sub2.sup")
         let frenchTonemapped = URL(fileURLWithPath: "/tmp/sub4.sup")
         builder.subtitleStreamActions = [
-            (streamIndex: 2, action: .replaceWith(englishTonemapped)),
-            (streamIndex: 3, action: .drop),
-            (streamIndex: 4, action: .replaceWith(frenchTonemapped)),
-            (streamIndex: 5, action: .passthrough),
+            .init(streamIndex: 2, action: .replaceWith(englishTonemapped)),
+            .init(streamIndex: 3, action: .drop),
+            .init(streamIndex: 4, action: .replaceWith(frenchTonemapped)),
+            .init(streamIndex: 5, action: .passthrough),
         ]
 
         let args = builder.build()
@@ -395,7 +395,7 @@ final class ConverterEngineTests: XCTestCase {
             URL(fileURLWithPath: "/tmp/extra-b.mkv"),
         ]
         builder.subtitleStreamActions = [
-            (streamIndex: 2, action: .replaceWith(URL(fileURLWithPath: "/tmp/sub.sup"))),
+            .init(streamIndex: 2, action: .replaceWith(URL(fileURLWithPath: "/tmp/sub.sup"))),
         ]
 
         let args = builder.build()

--- a/Tests/ConverterEngineTests/ConverterEngineTests.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests.swift
@@ -406,6 +406,52 @@ final class ConverterEngineTests: XCTestCase {
         XCTAssertFalse(s.contains("-map 2:s:0"))
     }
 
+    /// Integration test for the EncodingJobConfig → builder
+    /// `subtitleStreamActions` thread-through (#409 commit 3). Builds
+    /// arguments from a job that carries a populated action list and
+    /// asserts the resulting FFmpeg command line carries the right
+    /// `-i` and `-map` shape — protecting the pipeline → engine →
+    /// builder data flow that EncodingEngine.encode populates.
+    func test_encodingJobConfig_threadsSubtitleStreamActionsToBuilder() {
+        let profile = EncodingProfile(
+            name: "tonemap-integration",
+            videoCodec: .h265,
+            videoCRF: 22,
+            audioCodec: .aacLC,
+            audioBitrate: 160_000,
+            subtitlePassthrough: true,
+            containerFormat: .mkv
+        )
+        var config = EncodingJobConfig(
+            inputURL: URL(fileURLWithPath: "/tmp/source.mkv"),
+            outputURL: URL(fileURLWithPath: "/tmp/output.mkv"),
+            profile: profile
+        )
+        let tonemapped = URL(fileURLWithPath: "/tmp/subtitle-2-tonemapped.sup")
+        config.subtitleStreamActions = [
+            .init(streamIndex: 2, action: .replaceWith(tonemapped)),
+            .init(streamIndex: 3, action: .passthrough),
+        ]
+
+        let args = config.buildArguments()
+        let s = args.joined(separator: " ")
+
+        // The tonemapped subtitle file must be added as an `-i` input.
+        XCTAssertTrue(s.contains("-i /tmp/subtitle-2-tonemapped.sup"),
+                      "Replacement subtitle file must be added as an "
+                      + "additional FFmpeg input via -i")
+        // Stream 2 maps from input 1 (the replacement file), NOT from
+        // the source. Stream 3 still passes through from the source.
+        XCTAssertTrue(s.contains("-map 1:s:0"),
+                      "Replaced stream 2 maps from input 1")
+        XCTAssertTrue(s.contains("-map 0:s:3"),
+                      "Stream 3 still passes through from source")
+        // The legacy `-map 0:s?` glob must NOT appear when explicit
+        // actions are set.
+        XCTAssertFalse(s.contains("-map 0:s?"),
+                       "Explicit actions override the legacy glob")
+    }
+
     /// Verifies basic argument building with H.265/AAC.
     func test_argumentBuilder_basicH265() {
         var builder = FFmpegArgumentBuilder()

--- a/Tests/ConverterEngineTests/ConverterEngineTests.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests.swift
@@ -278,6 +278,134 @@ final class ConverterEngineTests: XCTestCase {
     // MARK: - FFmpeg Argument Builder Tests
     // -----------------------------------------------------------------
 
+    // -- Subtitle stream actions (#409) -------------------------------
+    //
+    // The subtitleStreamActions field drives explicit per-source-stream
+    // subtitle mapping. These tests pin the resulting `-i` ordering
+    // and `-map` arguments so a future refactor cannot silently break
+    // the wiring between SubtitleTonemapPipeline and the encoder.
+
+    /// Empty subtitleStreamActions must leave existing passthrough
+    /// behaviour untouched — this is the backward-compat invariant for
+    /// every existing call site.
+    func test_argumentBuilder_subtitleActions_emptyKeepsLegacyBehaviour() {
+        var builder = FFmpegArgumentBuilder()
+        builder.inputURL = URL(fileURLWithPath: "/tmp/in.mkv")
+        builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
+        builder.subtitlePassthrough = true
+
+        let args = builder.build()
+        // Should fall through to the legacy `-map 0:s?` glob.
+        let s = args.joined(separator: " ")
+        XCTAssertTrue(s.contains("-map 0:s?"),
+                      "Empty subtitleStreamActions must keep legacy "
+                      + "passthrough behaviour (-map 0:s?)")
+    }
+
+    /// A single .passthrough action emits a specific -map per stream
+    /// index — replacing the loose `-map 0:s?` glob.
+    func test_argumentBuilder_subtitleActions_passthroughSpecificIndex() {
+        var builder = FFmpegArgumentBuilder()
+        builder.inputURL = URL(fileURLWithPath: "/tmp/in.mkv")
+        builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
+        builder.subtitleStreamActions = [
+            (streamIndex: 2, action: .passthrough),
+            (streamIndex: 3, action: .passthrough),
+        ]
+
+        let args = builder.build()
+        let s = args.joined(separator: " ")
+        XCTAssertTrue(s.contains("-map 0:s:2"))
+        XCTAssertTrue(s.contains("-map 0:s:3"))
+        // The legacy glob must NOT appear when explicit actions are set.
+        XCTAssertFalse(s.contains("-map 0:s?"))
+    }
+
+    /// A .replaceWith action adds the file as an `-i` input and maps
+    /// from the replacement input rather than the source. The
+    /// replacement file's FFmpeg input index is `1 + additionalInputs
+    /// .count + replacementOrdinal` — pinned here because the encoder
+    /// pipeline relies on this ordering.
+    func test_argumentBuilder_subtitleActions_replaceWithAddsInputAndMaps() {
+        var builder = FFmpegArgumentBuilder()
+        builder.inputURL = URL(fileURLWithPath: "/tmp/in.mkv")
+        builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
+        let tonemapped = URL(fileURLWithPath: "/tmp/sub2.sup")
+        builder.subtitleStreamActions = [
+            (streamIndex: 2, action: .replaceWith(tonemapped)),
+        ]
+
+        let args = builder.build()
+        let s = args.joined(separator: " ")
+        // Replacement file is added as -i AFTER inputURL.
+        XCTAssertTrue(s.contains("-i /tmp/in.mkv"))
+        XCTAssertTrue(s.contains("-i /tmp/sub2.sup"))
+        // Source's subtitle stream at index 2 is suppressed (no -map 0:s:2)
+        // and the replacement is mapped from input 1 instead.
+        XCTAssertFalse(s.contains("-map 0:s:2"))
+        XCTAssertTrue(s.contains("-map 1:s:0"))
+    }
+
+    /// Mixed actions across multiple streams must produce the right
+    /// input list AND `-map` directives in source-stream order. This
+    /// is the realistic case: one passthrough, one replacement, one
+    /// drop on a multi-language source.
+    func test_argumentBuilder_subtitleActions_mixedActionsCorrectMapping() {
+        var builder = FFmpegArgumentBuilder()
+        builder.inputURL = URL(fileURLWithPath: "/tmp/in.mkv")
+        builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
+        let englishTonemapped = URL(fileURLWithPath: "/tmp/sub2.sup")
+        let frenchTonemapped = URL(fileURLWithPath: "/tmp/sub4.sup")
+        builder.subtitleStreamActions = [
+            (streamIndex: 2, action: .replaceWith(englishTonemapped)),
+            (streamIndex: 3, action: .drop),
+            (streamIndex: 4, action: .replaceWith(frenchTonemapped)),
+            (streamIndex: 5, action: .passthrough),
+        ]
+
+        let args = builder.build()
+        // Both replacement files appear as -i inputs (after source).
+        XCTAssertEqual(
+            args.filter { $0 == "-i" }.count,
+            3,
+            "Expected 3 -i flags: source + 2 replacement files"
+        )
+        // FFmpeg input indices: source=0, english=1, french=2.
+        // (drop has no input.) Pin the -map list shape.
+        let s = args.joined(separator: " ")
+        XCTAssertTrue(s.contains("-map 1:s:0"),
+                      "English tonemapped subtitle from input 1")
+        XCTAssertTrue(s.contains("-map 2:s:0"),
+                      "French tonemapped subtitle from input 2")
+        XCTAssertTrue(s.contains("-map 0:s:5"),
+                      "Stream 5 passes through from source")
+        // Dropped stream 3 has no -map.
+        XCTAssertFalse(s.contains("-map 0:s:3"))
+    }
+
+    /// When the caller already has unrelated `additionalInputs`, the
+    /// replacement input indices must be offset past them. Protects
+    /// the ordering contract documented on `subtitleStreamActions`.
+    func test_argumentBuilder_subtitleActions_replacementsOffsetByAdditionalInputs() {
+        var builder = FFmpegArgumentBuilder()
+        builder.inputURL = URL(fileURLWithPath: "/tmp/in.mkv")
+        builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
+        builder.additionalInputs = [
+            URL(fileURLWithPath: "/tmp/extra-a.mkv"),
+            URL(fileURLWithPath: "/tmp/extra-b.mkv"),
+        ]
+        builder.subtitleStreamActions = [
+            (streamIndex: 2, action: .replaceWith(URL(fileURLWithPath: "/tmp/sub.sup"))),
+        ]
+
+        let args = builder.build()
+        let s = args.joined(separator: " ")
+        // additionalInputs occupy 1 and 2 → replacement is input 3.
+        XCTAssertTrue(s.contains("-map 3:s:0"))
+        XCTAssertFalse(s.contains("-map 1:s:0"))
+        XCTAssertFalse(s.contains("-map 2:s:0"))
+    }
+
     /// Verifies basic argument building with H.265/AAC.
     func test_argumentBuilder_basicH265() {
         var builder = FFmpegArgumentBuilder()


### PR DESCRIPTION
## Summary

Closes [#409](../issues/409) and completes the end-to-end subtitle tone-mapping path that was started in #369 (engine binary) and #397 (UI binding) and got its pre-processing helper in #410. The OutputSettingsView toggle now actually changes the output bytes — when the user opts in, HDR subtitle streams are extracted, run through \`subtitle_tonemap\`, and remapped into the FFmpeg encode.

## What's in the PR

Five commits, in the order each piece becomes useful:

| Commit | Topic |
|--------|-------|
| \`787acf2\` | \`FFmpegArgumentBuilder\` gains \`SubtitleStreamAction\` (passthrough / replaceWith(URL) / drop) + \`subtitleStreamActions\` field + \`build()\` integration |
| \`740fcec\` | Five unit tests for the builder's new subtitle-mapping behaviour (empty actions keep legacy behaviour; passthrough emits specific index; replaceWith adds \`-i\` and maps from it; mixed-actions correctness; offset by \`additionalInputs\`) |
| \`28ebfd5\` | \`EncodingJobConfig\` threads \`subtitleStreamActions\` to the builder. Required promoting \`SubtitleStreamAction\` to Codable and replacing the tuple element type with a tiny Codable struct (\`SubtitleStreamActionEntry\`) so EncodingJobConfig's own Codable synthesis keeps working |
| \`14effef\` | \`EncodingEngine.encode()\` calls \`SubtitleTonemapPipeline.run(...)\` as a pre-processing stage and populates \`enrichedJob.subtitleStreamActions\` from the result |
| \`48f8e75\` | One integration test pinning the full data flow: a populated \`EncodingJobConfig.subtitleStreamActions\` produces the expected \`-i\` + \`-map\` shape in \`buildArguments()\` |

## How it behaves at the call site

When the user has subtitle tone-mapping enabled on a profile AND the source is HDR AND subtitles are passing through AND at least one supported subtitle codec is present (PGS or ASS/SSA):

1. \`SubtitleTonemapPipeline.run(...)\` extracts each candidate stream via the engine's progress-aware FFmpeg runner, runs \`subtitle_tonemap\` on each, and returns per-stream tone-mapped file URLs.
2. EncodingEngine builds a full per-source-stream action list — \`.replaceWith(tonemappedFile)\` for each successful stream, \`.passthrough\` for every other subtitle stream (so non-tonemapped streams aren't silently dropped).
3. \`buildArguments()\` emits one \`-i\` per replacement file (after \`inputURL\` and any pre-existing \`additionalInputs\`) and one \`-map\` per action (\`-map N:s:0\` for replacements, \`-map 0:s:K\` for passthrough, nothing for drop).

When any of the preconditions doesn't hold (config nil, SDR source, no supported codec, \`subtitle_tonemap\` binary unavailable), the pipeline returns empty and the encoder falls back to legacy \`subtitlePassthrough\` behaviour. No existing call site is affected.

## Test plan

- [x] \`swift build\` clean.
- [x] 6 new tests pass; 17 subtitle-related tests in total green.
- [ ] After merge: with subtitle tone-mapping enabled on a profile, encode a PGS-subtitled HDR source and confirm the output's subtitle stream is SDR-coloured.

## Notes

- The pipeline's no-op cases mean this is safe to enable in default profiles for users; users without HDR sources or without the \`subtitle_tonemap\` binary just see no change.
- \`#374\` (the inline-provider cleanup) is still gated on \`SUITE_CORE\` becoming default; nothing here affects that.
- Two non-admin merges in a row landed in main today (#411 + #412); this would be the third if branch-protection holds up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)