### PR TITLE
Fix SPM cache key (hashing gitignored file) + CHANGELOG backfill for 2026-05-20

### DIFF
--- a/.github/workflows/beta-alpha.yml
+++ b/.github/workflows/beta-alpha.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build
-          key: ${{ runner.os }}-spm-prerelease-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-spm-prerelease-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-prerelease-
             ${{ runner.os }}-spm-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build
-          key: ${{ runner.os }}-spm-codeql-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-spm-codeql-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-codeql-
             ${{ runner.os }}-spm-

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build
-          key: ${{ runner.os }}-spm-dev-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-spm-dev-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-dev-
             ${{ runner.os }}-spm-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build
-          key: ${{ runner.os }}-spm-release-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-spm-release-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-release-
             ${{ runner.os }}-spm-

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .build
-          key: ${{ runner.os }}-spm-testflight-${{ hashFiles('Package.resolved') }}
+          key: ${{ runner.os }}-spm-testflight-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: ${{ runner.os }}-spm-
 
       # ---------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,60 @@
 
 ## [Unreleased]
 
+### Added -- 2026-05-20 (subtitle tone-mapping end-to-end + workflow polish)
+
+- **Subtitle tone-mapping reaches the output bytes** -- the
+  OutputSettingsView toggle that landed in PR #397 was previously
+  cosmetic: the per-profile `subtitleTonemap` config was stored but
+  no encoding-pipeline code consumed it. PR #413 closes the loop in
+  five steps:
+    1. `FFmpegArgumentBuilder.SubtitleStreamAction` (passthrough /
+       replaceWith(URL) / drop) + `subtitleStreamActions` field
+       drives per-source-stream subtitle mapping when non-empty
+    2. Five unit tests for the builder
+    3. `EncodingJobConfig` threads `subtitleStreamActions` to the
+       builder (introduced `SubtitleStreamActionEntry` Codable struct)
+    4. `EncodingEngine.encode()` calls `SubtitleTonemapPipeline.run(...)`
+       as a pre-processing stage and populates
+       `enrichedJob.subtitleStreamActions` from the result
+    5. Integration test pinning the full data flow
+  (PR #413, closes #409 / completes the chain that started with #369
+  engine and #397 UI binding)
+
+### Fixed -- 2026-05-20 (workflow infrastructure)
+
+- **CodeQL workflow cancellations**: the 75-minute timeout cap was
+  insufficient on slow `macos-15` runners — same code completing in
+  24 minutes on one runner but cancelling at 77 minutes on another.
+  Diagnosis revealed CodeQL's Swift extractor re-instruments every
+  compile invocation, so SPM caching cannot short-circuit the
+  dominant cost. Timeout raised to 120 minutes for hardware-variance
+  headroom. (PR #412)
+- **SPM cache step in codeql.yml**: previously cold every run, now
+  matches the pattern in build.yml/release.yml. The cache itself
+  saves only ~30 s of SPM-download time but provides a baseline for
+  future tuning. (PR #411)
+- **SPM cache key was hashing a gitignored file**: all six workflows
+  used `hashFiles('Package.resolved')`, but Package.resolved is in
+  .gitignore and absent at runner checkout time — the hash was
+  always empty and every cache went to a single per-prefix bucket.
+  Fixed to `hashFiles('Package.swift', 'Package.resolved')` so the
+  always-tracked Package.swift drives discrimination today, and a
+  future policy change to commit Package.resolved adds exact-version
+  precision for free. Affects build.yml, beta-alpha.yml, codeql.yml,
+  dev-build.yml, release.yml, testflight.yml. (this batch)
+
+### Operations -- 2026-05-20
+
+- **Branch protection cleanup**: removed the PR-review requirement
+  on main, updated the required-status-check context name to match
+  what CI actually reports (`Build & Test (macOS)`), and rewrote the
+  "Protect main branch" repository ruleset to require the actual
+  check name rather than the template defaults (`Frontend
+  (ubuntu-latest)` / `Backend (ubuntu-latest)`) it had been carrying
+  since project creation. PRs now merge without `--admin` once
+  Build & Test passes.
+
 ### Added -- 2026-05-18 (UI gap closure for #381 + audit follow-ups)
 
 - **Subtitle tone-mapping UI** -- `OutputSettingsView` gains a new


### PR DESCRIPTION
## Summary

Two commits, both housekeeping.

### Commit 1 — \`04fde20\` — fix the SPM cache key across all six workflows

PR #411 added an SPM cache to codeql.yml on the theory that cold-start \`swift build\` was the dominant cost. We later proved that theory wrong (the real fix was the timeout bump in PR #412), and while diagnosing it I found the cache key itself is broken:

\`\`\`yaml
key: ${{ runner.os }}-spm-codeql-${{ hashFiles('Package.resolved') }}
\`\`\`

\`Package.resolved\` is in \`.gitignore\`, so it doesn't exist at runner checkout. \`hashFiles()\` returns an empty string for missing files. The resulting key is literally \`macOS-spm-codeql-\` — a single bucket for ALL package configurations. The same bug exists in **five other workflows** that copied the same pattern (build.yml, release.yml, beta-alpha.yml, testflight.yml, dev-build.yml).

Fix: \`hashFiles('Package.swift', 'Package.resolved')\`. Package.swift is always tracked → the hash is never empty. The dependency *constraints* declared in Package.swift drive cache discrimination, which is the closest we can get without changing gitignore policy. If Package.resolved is ever committed in the future, hashFiles picks it up automatically and the hash becomes per-pinned-version.

### Commit 2 — \`517cde4\` — CHANGELOG backfill for today

Three new sub-sections under \`[Unreleased]\`:
- **Added**: subtitle tone-mapping end-to-end (PR #413 closes #409)
- **Fixed**: today's three CI infra fixes (#411 cache step, #412 timeout, this batch's hashFiles fix)
- **Operations**: branch-protection cleanup that lets PRs merge without \`--admin\`

Format mirrors the existing 2026-05-18 entries.

## Test plan

- [x] All six workflow files pass \`python3 -c "import yaml; yaml.safe_load(...)"\`.
- [x] Diff shows exactly one line per workflow changed.
- [ ] After merge: the next post-push CodeQL run on main will use a fresh cache key (\`macOS-spm-codeql-<hash-of-Package.swift>\`) — and start populating a properly-discriminated cache. Subsequent runs with unchanged dependencies should get an exact-key hit instead of the prefix-fallback hit they've been getting until now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)