### PR TITLE
Fix clean-dev-caches.sh dry-run label always showing

### DIFF
--- a/scripts/clean-dev-caches.sh
+++ b/scripts/clean-dev-caches.sh
@@ -130,7 +130,14 @@ clean_target() {
 # Cleanup pass
 # -----------------------------------------------------------------------------
 
-echo "MeedyaConverter dev-cache cleaner — mode: $MODE${DRY_RUN:+ (dry run)}"
+# Header label. `${DRY_RUN:+...}` would expand for the integer 0 too
+# (DRY_RUN is non-empty when set to the default 0), so use an explicit
+# `if` instead — keeps the label honest when --dry-run is NOT passed.
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "MeedyaConverter dev-cache cleaner — mode: $MODE (dry run)"
+else
+  echo "MeedyaConverter dev-cache cleaner — mode: $MODE"
+fi
 echo "Project root: $PROJECT_ROOT"
 echo ""
 


### PR DESCRIPTION
## Summary

PR #417's script always printed \`(dry run)\` in its header — even when \`--dry-run\` was NOT passed:

\`\`\`
$ ./scripts/clean-dev-caches.sh --quick
MeedyaConverter dev-cache cleaner — mode: quick (dry run)   ← lies
...
Cleaned 3 target(s); freed approximately 1 GiB.             ← but it really cleaned
\`\`\`

## Cause

The header used \`\${DRY_RUN:+ (dry run)}\`. That bash parameter expansion adds the suffix whenever \`DRY_RUN\` is set to ANY non-empty string — and the default value of \`DRY_RUN=0\` is the non-empty string \"0\", so the suffix always appeared. The actual delete-or-skip logic uses \`[[ \$DRY_RUN -eq 1 ]]\` and is correct, so this was always cosmetic-only.

## Fix

Explicit \`if [[ \$DRY_RUN -eq 1 ]]\` test for the header, matching the rest of the script.

Verified locally — both modes now print the right header:

\`\`\`
$ ./scripts/clean-dev-caches.sh --dry-run | head -1
MeedyaConverter dev-cache cleaner — mode: quick (dry run)

$ ./scripts/clean-dev-caches.sh --quick | head -1
MeedyaConverter dev-cache cleaner — mode: quick
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)