### PR TITLE
GA honesty fixes: real Apply/QC/SFTP-test execution + disable un-shippable controls (#444–#447, #449)

### DIFF
--- a/Sources/ConverterEngine/Utilities/QualityChecker.swift
+++ b/Sources/ConverterEngine/Utilities/QualityChecker.swift
@@ -39,11 +39,30 @@ public enum QCCheckType: String, Codable, Sendable, CaseIterable {
 }
 
 // ---------------------------------------------------------------------------
+// MARK: - QCStatus
+// ---------------------------------------------------------------------------
+/// The verdict of a single quality-control check.
+///
+/// Distinguishes a genuinely-executed check's pass/fail outcome from a
+/// check that has no real detector behind it yet. Introduced by Issue #445
+/// so that unimplemented checks (``QualityChecker/runAllChecks(inputPath:profile:)``'s
+/// former `audioSync`/`levelCompliance`/`corruptFrames`/`formatConformance`
+/// stubs) can never be reported as a fabricated ``passed`` result.
+public enum QCStatus: String, Codable, Sendable {
+    /// The check actually ran and found no issue.
+    case passed
+    /// The check actually ran and found an issue.
+    case failed
+    /// The check has no real detector implemented yet and did not run.
+    case notImplemented
+}
+
+// ---------------------------------------------------------------------------
 // MARK: - QCResult
 // ---------------------------------------------------------------------------
 /// The outcome of a single quality-control check against a media file.
 ///
-/// Each result carries a pass/fail verdict, a human-readable ``details``
+/// Each result carries a ``status`` verdict, a human-readable ``details``
 /// string describing what was found, and an optional ``timestamp`` pointing
 /// to the location in the file where the issue was detected.
 ///
@@ -57,8 +76,9 @@ public struct QCResult: Identifiable, Codable, Sendable {
     /// The type of check that produced this result.
     public let check: QCCheckType
 
-    /// Whether the check passed (`true`) or found an issue (`false`).
-    public let passed: Bool
+    /// The verdict for this check: ``QCStatus/passed``, ``QCStatus/failed``,
+    /// or ``QCStatus/notImplemented`` when no real detector ran.
+    public let status: QCStatus
 
     /// Human-readable description of the finding.
     public let details: String
@@ -69,18 +89,24 @@ public struct QCResult: Identifiable, Codable, Sendable {
     /// Severity level: "info", "warning", or "error".
     public let severity: String
 
+    /// Convenience accessor: `true` only when the check actually ran and
+    /// passed. `false` for both a genuine failure and a not-implemented
+    /// check — callers that need to distinguish the two should switch on
+    /// ``status`` directly rather than relying on this shortcut.
+    public var passed: Bool { status == .passed }
+
     /// Memberwise initializer.
     public init(
         id: UUID = UUID(),
         check: QCCheckType,
-        passed: Bool,
+        status: QCStatus,
         details: String,
         timestamp: TimeInterval? = nil,
         severity: String = "info"
     ) {
         self.id = id
         self.check = check
-        self.passed = passed
+        self.status = status
         self.details = details
         self.timestamp = timestamp
         self.severity = severity
@@ -248,7 +274,7 @@ public struct QualityChecker: Sendable {
         guard let regex = try? NSRegularExpression(pattern: pattern) else {
             return [QCResult(
                 check: .blackFrames,
-                passed: true,
+                status: .passed,
                 details: "No black frames detected (parse unavailable).",
                 severity: "info"
             )]
@@ -268,7 +294,7 @@ public struct QualityChecker: Sendable {
 
             results.append(QCResult(
                 check: .blackFrames,
-                passed: false,
+                status: .failed,
                 details: String(
                     format: "Black segment at %.2fs, duration %.2fs",
                     start, duration
@@ -281,7 +307,7 @@ public struct QualityChecker: Sendable {
         if results.isEmpty {
             results.append(QCResult(
                 check: .blackFrames,
-                passed: true,
+                status: .passed,
                 details: "No black frames detected.",
                 severity: "info"
             ))
@@ -309,7 +335,7 @@ public struct QualityChecker: Sendable {
               let endRegex = try? NSRegularExpression(pattern: endPattern) else {
             return [QCResult(
                 check: .silenceDetection,
-                passed: true,
+                status: .passed,
                 details: "No silence detected (parse unavailable).",
                 severity: "info"
             )]
@@ -341,7 +367,7 @@ public struct QualityChecker: Sendable {
 
             results.append(QCResult(
                 check: .silenceDetection,
-                passed: false,
+                status: .failed,
                 details: String(
                     format: "Silence at %.2fs, duration %.2fs",
                     startTime, duration
@@ -354,7 +380,7 @@ public struct QualityChecker: Sendable {
         if results.isEmpty {
             results.append(QCResult(
                 check: .silenceDetection,
-                passed: true,
+                status: .passed,
                 details: "No silence detected.",
                 severity: "info"
             ))
@@ -365,24 +391,37 @@ public struct QualityChecker: Sendable {
 
     // MARK: - Batch Runner
 
-    /// Runs all enabled checks from the given profile and returns
-    /// aggregated results.
+    /// Resolves every enabled check from the given profile that does
+    /// **not** require executing an FFmpeg process, and returns their
+    /// honest results (Issue #445).
     ///
-    /// This method does **not** execute FFmpeg processes directly. For
-    /// checks that require FFmpeg analysis (black frames, silence), it
-    /// returns placeholder results indicating the check is pending. The
-    /// caller is responsible for running the FFmpeg commands returned by
-    /// ``buildBlackFrameDetectionArgs(inputPath:)`` and
-    /// ``buildSilenceDetectionArgs(inputPath:threshold:)`` and then
-    /// parsing the output.
+    /// `blackFrames` and `silenceDetection` are deliberately **not**
+    /// included in this method's output: they have real detectors
+    /// (``buildBlackFrameDetectionArgs(inputPath:)`` /
+    /// ``parseBlackFrameOutput(_:)`` and
+    /// ``buildSilenceDetectionArgs(inputPath:threshold:)`` /
+    /// ``parseSilenceOutput(_:)``), but running them means executing
+    /// FFmpeg — something this pure-function utility does not do (see the
+    /// type-level documentation). Callers that enable those checks must
+    /// run the FFmpeg commands themselves via `FFmpegProcessController`,
+    /// parse the output with the corresponding `parse...Output(_:)`
+    /// function, and merge those results with this method's output — see
+    /// `QualityCheckView.runQualityChecks()` for the reference
+    /// implementation.
     ///
-    /// Non-FFmpeg checks (audio sync, level compliance, format conformance,
-    /// corrupt frames) produce stub results suitable for future expansion.
+    /// The remaining checks — `audioSync`, `levelCompliance`,
+    /// `corruptFrames`, and `formatConformance` — have no real detector
+    /// implemented yet. Previously this method reported a fabricated
+    /// `passed: true` for all four (and `formatConformance` conflated mere
+    /// file existence with genuine conformance validation); it now reports
+    /// ``QCStatus/notImplemented`` for every one of them so a stub can
+    /// never be rendered or exported as a passing check.
     ///
     /// - Parameters:
     ///   - inputPath: Absolute path to the media file.
     ///   - profile: The ``QCProfile`` controlling which checks to run.
-    /// - Returns: Array of ``QCResult`` values for all enabled checks.
+    /// - Returns: Array of ``QCResult`` values for the enabled checks this
+    ///   method can resolve without running FFmpeg.
     public static func runAllChecks(
         inputPath: String,
         profile: QCProfile
@@ -391,31 +430,16 @@ public struct QualityChecker: Sendable {
 
         for check in profile.enabledChecks.sorted(by: { $0.rawValue < $1.rawValue }) {
             switch check {
-            case .blackFrames:
-                // Caller must run buildBlackFrameDetectionArgs and parse output.
-                results.append(QCResult(
-                    check: .blackFrames,
-                    passed: true,
-                    details: "Black frame detection requires FFmpeg execution. "
-                           + "Use buildBlackFrameDetectionArgs() and parseBlackFrameOutput().",
-                    severity: "info"
-                ))
-
-            case .silenceDetection:
-                // Caller must run buildSilenceDetectionArgs and parse output.
-                results.append(QCResult(
-                    check: .silenceDetection,
-                    passed: true,
-                    details: "Silence detection requires FFmpeg execution. "
-                           + "Use buildSilenceDetectionArgs() and parseSilenceOutput().",
-                    severity: "info"
-                ))
+            case .blackFrames, .silenceDetection:
+                // Requires running FFmpeg — resolved by the caller (e.g.
+                // QualityCheckView), not here. Intentionally not appended.
+                continue
 
             case .audioSync:
                 results.append(QCResult(
                     check: .audioSync,
-                    passed: true,
-                    details: "Audio sync verification pending implementation.",
+                    status: .notImplemented,
+                    details: "Audio sync verification has no detector implemented yet.",
                     severity: "info"
                 ))
 
@@ -423,28 +447,35 @@ public struct QualityChecker: Sendable {
                 let standard = profile.loudnessStandard ?? "unspecified"
                 results.append(QCResult(
                     check: .levelCompliance,
-                    passed: true,
-                    details: "Level compliance (\(standard)) pending implementation.",
+                    status: .notImplemented,
+                    details: "Level compliance (\(standard)) has no detector implemented yet.",
                     severity: "info"
                 ))
 
             case .formatConformance:
-                // Basic file-existence check as a placeholder.
+                // A real conformance check would validate container/codec
+                // parameters against a target spec; only file existence can
+                // currently be verified, which is not the same claim, so
+                // this is reported as not-implemented rather than a pass —
+                // the existence check is still surfaced in `details` since
+                // a missing file is useful, unambiguous information.
                 let exists = FileManager.default.fileExists(atPath: inputPath)
                 results.append(QCResult(
                     check: .formatConformance,
-                    passed: exists,
+                    status: .notImplemented,
                     details: exists
-                        ? "File exists and is accessible."
-                        : "File not found at path: \(inputPath)",
+                        ? "Format conformance validation has no detector implemented yet "
+                          + "(file exists and is accessible)."
+                        : "Format conformance validation has no detector implemented yet, "
+                          + "and the file was not found at path: \(inputPath).",
                     severity: exists ? "info" : "error"
                 ))
 
             case .corruptFrames:
                 results.append(QCResult(
                     check: .corruptFrames,
-                    passed: true,
-                    details: "Corrupt frame detection pending implementation.",
+                    status: .notImplemented,
+                    details: "Corrupt frame detection has no detector implemented yet.",
                     severity: "info"
                 ))
             }

--- a/Sources/MeedyaConverter/Views/DuplicateFinderView.swift
+++ b/Sources/MeedyaConverter/Views/DuplicateFinderView.swift
@@ -106,7 +106,16 @@ struct DuplicateFinderView: View {
             }
 
             Picker("Method:", selection: $selectedMethod) {
-                ForEach(MatchType.allCases, id: \.self) { method in
+                // TODO(#449): re-enable when perceptual-hash matching is
+                // implemented. `.perceptual` is filtered out of the
+                // selectable options here because
+                // `DuplicateDetector.findDuplicates(in:method:)` returns an
+                // empty result for it unconditionally
+                // (DuplicateDetector.swift:101-104) — there is no pHash
+                // implementation behind it yet, so exposing it would let
+                // the user "successfully" run a scan that can never find
+                // anything, with no indication anything is wrong.
+                ForEach(MatchType.allCases.filter { $0 != .perceptual }, id: \.self) { method in
                     Text(method.rawValue).tag(method)
                 }
             }

--- a/Sources/MeedyaConverter/Views/QualityCheckView.swift
+++ b/Sources/MeedyaConverter/Views/QualityCheckView.swift
@@ -43,6 +43,18 @@ struct QualityCheckView: View {
     /// Controls visibility of the export save panel.
     @State private var showExportPanel = false
 
+    // MARK: - Run Execution State (Issue #445)
+
+    /// The in-flight QC run task, retained so it can be cancelled when the
+    /// user navigates away from this view while checks are executing.
+    /// Mirrors `LoudnessReportView.analysisTask` / `BenchmarkView.benchmarkTask`.
+    @State private var runTask: Task<Void, Never>?
+
+    /// The FFmpeg process controller for the black-frame/silence pass
+    /// currently running, retained so `cancelRun()` can stop the running
+    /// process rather than merely abandoning it.
+    @State private var currentController: FFmpegProcessController?
+
     /// Available built-in profile names for the picker.
     private let profileNames = ["Broadcast", "Streaming", "Archive"]
 
@@ -58,14 +70,19 @@ struct QualityCheckView: View {
         }
     }
 
-    /// Number of checks that passed in the current results.
+    /// Number of checks that actually ran and passed in the current results.
     private var passCount: Int {
-        results.filter(\.passed).count
+        results.filter { $0.status == .passed }.count
     }
 
-    /// Number of checks that failed in the current results.
+    /// Number of checks that actually ran and failed in the current results.
     private var failCount: Int {
-        results.filter { !$0.passed }.count
+        results.filter { $0.status == .failed }.count
+    }
+
+    /// Number of checks that were enabled but have no real detector yet.
+    private var notImplementedCount: Int {
+        results.filter { $0.status == .notImplemented }.count
     }
 
     // MARK: - Body
@@ -87,6 +104,7 @@ struct QualityCheckView: View {
             }
         }
         .frame(minWidth: 500, minHeight: 400)
+        .onDisappear { cancelRun() }
     }
 
     // MARK: - Toolbar
@@ -173,7 +191,7 @@ struct QualityCheckView: View {
         }
     }
 
-    /// Summary bar showing pass/fail counts.
+    /// Summary bar showing pass/fail/not-implemented counts.
     private var summaryBar: some View {
         HStack(spacing: 16) {
             Label("\(passCount) Passed", systemImage: "checkmark.circle.fill")
@@ -181,6 +199,9 @@ struct QualityCheckView: View {
 
             Label("\(failCount) Failed", systemImage: "xmark.circle.fill")
                 .foregroundStyle(failCount > 0 ? .red : .secondary)
+
+            Label("\(notImplementedCount) Not Implemented", systemImage: "minus.circle.fill")
+                .foregroundStyle(.secondary)
 
             Spacer()
 
@@ -193,15 +214,31 @@ struct QualityCheckView: View {
         .background(.bar)
     }
 
-    /// A single result row with pass/fail badge, severity, and details.
+    /// Icon for a check's status badge.
+    private func statusIcon(_ status: QCStatus) -> String {
+        switch status {
+        case .passed: return "checkmark.circle.fill"
+        case .failed: return "xmark.circle.fill"
+        case .notImplemented: return "minus.circle.fill"
+        }
+    }
+
+    /// Colour for a check's status badge.
+    private func statusColor(_ status: QCStatus) -> Color {
+        switch status {
+        case .passed: return .green
+        case .failed: return .red
+        case .notImplemented: return .secondary
+        }
+    }
+
+    /// A single result row with a status badge, severity, and details.
     private func resultRow(_ result: QCResult) -> some View {
         HStack(spacing: 12) {
-            // Pass/fail badge
-            Image(systemName: result.passed
-                  ? "checkmark.circle.fill"
-                  : "xmark.circle.fill")
-            .foregroundStyle(result.passed ? .green : .red)
-            .font(.title3)
+            // Status badge (pass / fail / not implemented — Issue #445)
+            Image(systemName: statusIcon(result.status))
+                .foregroundStyle(statusColor(result.status))
+                .font(.title3)
 
             VStack(alignment: .leading, spacing: 2) {
                 // Check type
@@ -288,6 +325,28 @@ struct QualityCheckView: View {
     // MARK: - Actions
 
     /// Executes quality checks using the selected profile.
+    ///
+    /// Mirrors the execution pattern proven in
+    /// `QualityMetricsView.runAnalysis()` (Issue #434): locate FFmpeg via
+    /// `FFmpegBundleManager`, build arguments with the existing
+    /// `QualityChecker.buildBlackFrameDetectionArgs`/
+    /// `buildSilenceDetectionArgs` builders, run them through
+    /// `FFmpegProcessController.startEncoding(arguments:)`, then parse the
+    /// real stderr output with `QualityChecker.parseBlackFrameOutput`/
+    /// `parseSilenceOutput` (Issue #445). `QualityChecker` itself stays a
+    /// pure, process-free utility (per its own documentation), so this view
+    /// is where the actual FFmpeg execution for the two checks that have
+    /// real detectors happens; `QualityChecker.runAllChecks` supplies the
+    /// honest `.notImplemented` results for every other enabled check.
+    ///
+    /// `QualityCheckView` is a `struct: View`, not a `@MainActor` class, so
+    /// (like the sibling views in this file's neighbourhood) its methods
+    /// are implicitly main-actor isolated via `View` conformance. A plain
+    /// `Task { }` here inherits that isolation, so `@State` mutations are
+    /// direct property writes. The one genuinely blocking call —
+    /// `FFmpegBundleManager.locateFFmpeg()` — is pulled into a
+    /// `Task.detached` that returns only a `Sendable` `String` and never
+    /// touches `self`/`@State`, so it never blocks the main thread.
     private func runQualityChecks() {
         guard let file = viewModel.selectedFile else {
             errorMessage = "No file selected."
@@ -297,21 +356,108 @@ struct QualityCheckView: View {
         isRunning = true
         errorMessage = nil
 
-        // Run checks asynchronously to avoid blocking the main thread.
-        Task {
-            let checkResults = QualityChecker.runAllChecks(
-                inputPath: file.fileURL.path,
-                profile: selectedProfile
+        let inputPath = file.fileURL.path
+        let profile = selectedProfile
+
+        runTask = Task {
+            // Checks with no FFmpeg execution requirement resolve
+            // synchronously and honestly: real results, or `.notImplemented`
+            // for stubs — never a fabricated pass.
+            var collectedResults = QualityChecker.runAllChecks(
+                inputPath: inputPath,
+                profile: profile
             )
 
-            await MainActor.run {
-                results = checkResults
-                isRunning = false
+            let needsFFmpeg = profile.enabledChecks.contains(.blackFrames)
+                || profile.enabledChecks.contains(.silenceDetection)
+
+            var ffmpegPath = ""
+            if needsFFmpeg {
+                do {
+                    ffmpegPath = try await Task.detached {
+                        try FFmpegBundleManager().locateFFmpeg().path
+                    }.value
+                } catch {
+                    errorMessage = "FFmpeg could not be found. Install FFmpeg or configure its location in Settings before running black-frame/silence checks."
+                    results = collectedResults.sorted { $0.check.rawValue < $1.check.rawValue }
+                    currentController = nil
+                    isRunning = false
+                    return
+                }
             }
+
+            if !Task.isCancelled, profile.enabledChecks.contains(.blackFrames) {
+                let controller = FFmpegProcessController(binaryPath: ffmpegPath)
+                currentController = controller
+                let args = QualityChecker.buildBlackFrameDetectionArgs(inputPath: inputPath)
+                do {
+                    let progressStream = try controller.startEncoding(arguments: args)
+                    for await _ in progressStream {
+                        if Task.isCancelled {
+                            controller.stopEncoding()
+                            break
+                        }
+                    }
+                    if !Task.isCancelled {
+                        collectedResults.append(contentsOf: QualityChecker.parseBlackFrameOutput(controller.errorOutput))
+                    }
+                } catch {
+                    errorMessage = "Black-frame detection failed: \(error.localizedDescription)"
+                }
+            }
+
+            if !Task.isCancelled, profile.enabledChecks.contains(.silenceDetection) {
+                let controller = FFmpegProcessController(binaryPath: ffmpegPath)
+                currentController = controller
+                let args = QualityChecker.buildSilenceDetectionArgs(
+                    inputPath: inputPath,
+                    threshold: profile.silenceThreshold
+                )
+                do {
+                    let progressStream = try controller.startEncoding(arguments: args)
+                    for await _ in progressStream {
+                        if Task.isCancelled {
+                            controller.stopEncoding()
+                            break
+                        }
+                    }
+                    if !Task.isCancelled {
+                        collectedResults.append(contentsOf: QualityChecker.parseSilenceOutput(controller.errorOutput))
+                    }
+                } catch {
+                    let prefix = errorMessage.map { "\($0) " } ?? ""
+                    errorMessage = "\(prefix)Silence detection failed: \(error.localizedDescription)"
+                }
+            }
+
+            currentController = nil
+            results = collectedResults.sorted { $0.check.rawValue < $1.check.rawValue }
+            isRunning = false
         }
     }
 
+    /// Cancel an in-progress QC run.
+    ///
+    /// Stops the currently-running FFmpeg process (if any) and cancels the
+    /// run `Task` so no process or task is left running in the background
+    /// after the user navigates away from this view mid-scan.
+    private func cancelRun() {
+        currentController?.stopEncoding()
+        currentController = nil
+        runTask?.cancel()
+        runTask = nil
+        isRunning = false
+    }
+
     /// Generates a plain-text QC report from the current results.
+    ///
+    /// Every enabled check is included — real pass/fail results for checks
+    /// that actually executed, and checks with no detector implemented are
+    /// clearly labelled `SKIPPED` rather than folded into the pass count
+    /// (Issue #445): the summary line below only tallies genuinely-executed
+    /// checks into "passed"/"failed", with skipped checks broken out
+    /// separately so the report can never be misread as more checks having
+    /// passed than actually ran.
     private func generateReport() -> String {
         var lines: [String] = []
         lines.append("Quality Control Report")
@@ -324,7 +470,12 @@ struct QualityCheckView: View {
         lines.append("")
 
         for result in results {
-            let status = result.passed ? "PASS" : "FAIL"
+            let status: String
+            switch result.status {
+            case .passed: status = "PASS"
+            case .failed: status = "FAIL"
+            case .notImplemented: status = "SKIPPED (not implemented)"
+            }
             let ts = result.timestamp.map { String(format: " @ %.2fs", $0) } ?? ""
             lines.append("[\(status)] \(result.check.rawValue)\(ts)")
             lines.append("  Severity: \(result.severity)")
@@ -333,7 +484,7 @@ struct QualityCheckView: View {
         }
 
         lines.append(String(repeating: "-", count: 60))
-        lines.append("Summary: \(passCount) passed, \(failCount) failed")
+        lines.append("Summary: \(passCount) passed, \(failCount) failed, \(notImplementedCount) skipped (not implemented)")
 
         return lines.joined(separator: "\n")
     }

--- a/Sources/MeedyaConverter/Views/SFTPSettingsView.swift
+++ b/Sources/MeedyaConverter/Views/SFTPSettingsView.swift
@@ -57,6 +57,11 @@ struct SFTPSettingsView: View {
     /// The result message from the last connection test.
     @State private var testResult: String?
 
+    /// The in-flight connection-test task, retained so a stale result
+    /// can't be written back after the user navigates away mid-probe
+    /// (Issue #447).
+    @State private var testTask: Task<Void, Never>?
+
     // MARK: - Auth Type Enum
 
     /// Simplified auth type picker for the UI, mapping to `AuthMethod`.
@@ -82,6 +87,7 @@ struct SFTPSettingsView: View {
                 .frame(minWidth: 400)
         }
         .onAppear(perform: loadProfiles)
+        .onDisappear { testTask?.cancel() }
     }
 
     // MARK: - Profile List
@@ -239,17 +245,174 @@ struct SFTPSettingsView: View {
         )
     }
 
-    /// Initiates a connection test using the current form values.
+    /// Initiates a real connection test using the current form values.
+    ///
+    /// **Issue #447**: this used to just call
+    /// `SFTPUploader.testConnection(config:)` to build the `ssh` argument
+    /// array and immediately report "Success: SSH arguments built" —
+    /// without ever launching a process. A typo'd host, an unreachable
+    /// server, or a rejected credential all reported the same fake
+    /// success. This now actually runs `ssh` against the configured
+    /// server and reports what really happened.
+    ///
+    /// Mirrors the execution pattern proven in
+    /// `VideoTrimmerView.applyTrim()` / `QualityMetricsView.runAnalysis()`
+    /// (Issue #434/#444): `SFTPSettingsView` is a `struct: View`, so its
+    /// methods are implicitly main-actor isolated via `View` conformance.
+    /// A plain `Task { }` here therefore inherits that isolation, so
+    /// `@State` writes (`testResult`, `isTesting`) are direct property
+    /// writes rather than `MainActor.run` hops. The one genuinely
+    /// blocking call — launching `ssh` and waiting for it to exit — is
+    /// kept off the main thread inside a `Task.detached` that captures
+    /// and returns only `Sendable` values (`SFTPServerConfig` in,
+    /// `ConnectionProbeResult` out), never `self`.
     private func testConnection() {
+        guard !isTesting else { return }
+
         isTesting = true
         testResult = nil
         let config = buildConfig()
-        let args = SFTPUploader.testConnection(config: config)
 
-        // Show the command that would be run (actual execution would
-        // use Process; here we just validate the arguments build).
-        testResult = args.isEmpty ? "Error: empty arguments" : "Success: SSH arguments built"
-        isTesting = false
+        testTask = Task {
+            let result = await Task.detached {
+                Self.probeConnection(config: config)
+            }.value
+
+            // The view may have disappeared (or a new test started) while
+            // the detached probe was running; don't clobber a newer state.
+            guard !Task.isCancelled else { return }
+
+            testResult = result.succeeded ? "Success: \(result.message)" : "Error: \(result.message)"
+            isTesting = false
+        }
+    }
+
+    /// The outcome of a real `ssh`-based connection probe.
+    private struct ConnectionProbeResult: Sendable {
+        /// Whether the server accepted the TCP connection, the host key,
+        /// and the configured credential.
+        let succeeded: Bool
+        /// A human-readable description of the result — a success
+        /// confirmation, or the real error `ssh` reported.
+        let message: String
+    }
+
+    /// Runs a real, non-interactive `ssh` probe against `config` and
+    /// reports the true outcome.
+    ///
+    /// Reuses `SFTPUploader.testConnection(config:)` — the argument
+    /// builder already written for this feature (Issue #312) that knows
+    /// how to wire up `-i <keyFile>` / SSH-agent defaults / `-o
+    /// BatchMode=no` per `AuthMethod`, plus `-o ConnectTimeout=10` for the
+    /// TCP phase — rather than inventing a new auth path. The one thing
+    /// added here is a single leading `-o BatchMode=yes`: per
+    /// `ssh_config(5)`, "for each parameter, the first obtained value
+    /// will be used," so this prepended flag wins over the `-o
+    /// BatchMode=no` the builder appends for `.password` profiles,
+    /// guaranteeing `ssh` can never block this app on a password/
+    /// passphrase prompt with no controlling terminal to read it from.
+    ///
+    /// Credentials never touch argv: `.agent` passes nothing, `.keyFile`
+    /// passes a filesystem path (not a secret), and `.password` profiles
+    /// are verified only for reachability, host-key acceptance, and any
+    /// already-loaded agent/key identity — SSH has no non-interactive way
+    /// to submit a plaintext password, so a password-only profile that
+    /// fails this probe is a true, disclosed limitation of the protocol,
+    /// not a fabricated failure.
+    ///
+    /// `nonisolated` and invoked from a `Task.detached` (see
+    /// `testConnection()`) so the blocking `waitUntilExit()` call never
+    /// runs on the main thread. A watchdog timer bounds the whole attempt
+    /// at 15s: `-o ConnectTimeout=10` only bounds the TCP connect phase,
+    /// not the handshake/auth phase that follows it, which `ssh` itself
+    /// does not bound.
+    private nonisolated static func probeConnection(
+        config: SFTPServerConfig
+    ) -> ConnectionProbeResult {
+        var args = ["-o", "BatchMode=yes"]
+        args.append(contentsOf: SFTPUploader.testConnection(config: config))
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+        process.arguments = args
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+        process.standardInput = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return ConnectionProbeResult(
+                succeeded: false,
+                message: "Could not launch ssh: \(error.localizedDescription)"
+            )
+        }
+
+        // Watchdog: SIGTERM at the deadline so a stalled handshake (a host
+        // that accepts the TCP connection but never completes SSH
+        // negotiation, which ConnectTimeout does not cover) can't hang the
+        // probe forever. `ssh` honours SIGTERM by default, so a single
+        // timer — no SIGKILL escalation — is sufficient for this
+        // lightweight, trusted-target probe (unlike the untrusted-input
+        // hardening in `FFmpegProbe.runFFprobe`).
+        let timeoutSeconds = 15.0
+        let watchdog = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        watchdog.schedule(deadline: .now() + timeoutSeconds)
+        watchdog.setEventHandler { [weak process] in
+            process?.terminate()
+        }
+        watchdog.activate()
+
+        // Drain both pipes concurrently so a chatty remote (e.g. a login
+        // banner/MOTD written to stdout) can't fill the pipe buffer and
+        // deadlock `waitUntilExit()` — the classic Process pipe-drain
+        // pitfall documented at `FFmpegProbe.runFFprobe`.
+        let ioState = ProbeIOState()
+        let stdoutDone = DispatchSemaphore(value: 0)
+        let stderrDone = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global(qos: .utility).async {
+            ioState.stdout = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            stdoutDone.signal()
+        }
+        DispatchQueue.global(qos: .utility).async {
+            ioState.stderr = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            stderrDone.signal()
+        }
+
+        process.waitUntilExit()
+        watchdog.cancel()
+        stdoutDone.wait()
+        stderrDone.wait()
+
+        // `terminate()` sends SIGTERM; a process that dies from an
+        // uncaught signal (rather than exiting normally) reports
+        // `.uncaughtSignal` here. `ssh` doesn't trap SIGTERM, so seeing
+        // this reliably means our watchdog — not the server — ended the
+        // attempt.
+        if process.terminationReason == .uncaughtSignal {
+            return ConnectionProbeResult(
+                succeeded: false,
+                message: "Connection attempt timed out after \(Int(timeoutSeconds))s."
+            )
+        }
+
+        guard process.terminationStatus == 0 else {
+            let stderrText = String(data: ioState.stderr, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let detail = stderrText.isEmpty
+                ? "ssh exited with status \(process.terminationStatus)."
+                : stderrText
+            return ConnectionProbeResult(succeeded: false, message: detail)
+        }
+
+        return ConnectionProbeResult(
+            succeeded: true,
+            message: "Connected and authenticated to \(config.username)@\(config.host)."
+        )
     }
 
     /// Saves the current form values as a profile.
@@ -439,4 +602,21 @@ struct SFTPSettingsView: View {
             UserDefaults.standard.set(data, forKey: Self.userDefaultsKey)
         }
     }
+}
+
+// MARK: - ProbeIOState
+
+/// Holds the drained stdout/stderr bytes from `probeConnection(config:)`'s
+/// `ssh` invocation.
+///
+/// `@unchecked Sendable`: the two background readers each own a disjoint
+/// property (`stdout`/`stderr`) and `probeConnection` only reads them
+/// after waiting on the `DispatchSemaphore` each reader signals on
+/// completion, so the semaphore hand-off — not the compiler — establishes
+/// the happens-before relationship. Mirrors the rationale documented on
+/// `FFmpegProbe.ProbeRunState`, which does the equivalent job with an
+/// `NSLock` instead of a semaphore.
+private final class ProbeIOState: @unchecked Sendable {
+    var stdout = Data()
+    var stderr = Data()
 }

--- a/Sources/MeedyaConverter/Views/VideoTrimmerView.swift
+++ b/Sources/MeedyaConverter/Views/VideoTrimmerView.swift
@@ -68,6 +68,22 @@ struct VideoTrimmerView: View {
     /// Error message to display, if any.
     @State private var errorMessage: String?
 
+    /// Success message to display after Apply genuinely completes, if any.
+    @State private var successMessage: String?
+
+    // MARK: - Apply Execution State (Issue #444)
+
+    /// The in-flight apply task, retained so it can be cancelled when the
+    /// user navigates away from this view while a trim/snip/split is
+    /// running. Mirrors `LoudnessReportView.analysisTask` /
+    /// `BenchmarkView.benchmarkTask`.
+    @State private var applyTask: Task<Void, Never>?
+
+    /// The FFmpeg process controller for the pass currently running,
+    /// retained so `cancelApply()` can stop the running process rather
+    /// than merely abandoning it.
+    @State private var currentController: FFmpegProcessController?
+
     // MARK: - Frame Navigation State (Issue #341)
 
     /// Whether frame-accurate mode is enabled.
@@ -105,6 +121,7 @@ struct VideoTrimmerView: View {
         .onChange(of: trimEndFraction) { _, _ in recalculateSegments() }
         .onChange(of: snipRegions) { _, _ in recalculateSegments() }
         .onAppear { recalculateSegments() }
+        .onDisappear { cancelApply() }
         // Drop a single video file to set as the trim source (Issue #366).
         .onDrop(
             of: [.fileURL, .movie, .video],
@@ -420,6 +437,16 @@ struct VideoTrimmerView: View {
                     .padding(.horizontal)
             }
 
+            // Success display (Issue #444) — only ever set after the
+            // FFmpeg process genuinely completes and its output file
+            // has been verified to exist on disk.
+            if let successMessage {
+                Text(successMessage)
+                    .font(.caption)
+                    .foregroundStyle(.green)
+                    .padding(.horizontal)
+            }
+
             // Apply button
             HStack {
                 Spacer()
@@ -481,18 +508,46 @@ struct VideoTrimmerView: View {
     }
 
     /// Execute the configured trim operation.
+    ///
+    /// Mirrors the execution pattern proven in
+    /// `QualityMetricsView.runAnalysis()` (Issue #434) and
+    /// `BenchmarkView.runStandardBenchmarks()` (Issue #435): locate FFmpeg
+    /// via `FFmpegBundleManager`, build arguments with the `VideoTrimmer`/
+    /// `VideoConcatenator` builders, run them through
+    /// `FFmpegProcessController.startEncoding(arguments:)`, and only report
+    /// success once the process has genuinely exited zero *and* the output
+    /// file has been verified to exist on disk (Issue #444).
+    ///
+    /// `VideoTrimmerView` is a `struct: View`, not a `@MainActor` class, so
+    /// — like the sibling views in this file's neighbourhood — its methods
+    /// are implicitly main-actor isolated via `View` conformance. A plain
+    /// `Task { }` here therefore inherits that isolation, so `@State`
+    /// mutations are direct property writes rather than `MainActor.run`
+    /// hops (matching `QualityMetricsView`'s post-Issue-#434 shape). Every
+    /// value captured into the task — paths, `TrimConfig`, the resulting
+    /// argument arrays — is `Sendable`, so nothing unsafe crosses the
+    /// closure boundary. The one genuinely blocking call —
+    /// `FFmpegBundleManager.locateFFmpeg()`, which blocks synchronously on
+    /// process exit — is still pulled into a `Task.detached` that returns
+    /// only a `Sendable` `String` and never touches `self`/`@State`, so it
+    /// never blocks the main thread.
     private func applyTrim() {
+        guard let file = viewModel.selectedFile else {
+            errorMessage = "No source file selected. Import a video file before applying a trim."
+            return
+        }
+
         errorMessage = nil
+        successMessage = nil
         isApplying = true
 
-        // Build the trim configuration
-        let splitBytes: Int64? = if let mb = Double(splitSizeMB) {
+        let splitBytes: Int64? = if let mb = Double(splitSizeMB), mb > 0 {
             Int64(mb * 1_048_576)
         } else {
             nil
         }
 
-        let _: TrimConfig = TrimConfig(
+        let config = TrimConfig(
             trimStart: trimStartFraction * duration,
             trimEnd: trimEndFraction * duration,
             snipRegions: snipRegions,
@@ -501,10 +556,272 @@ struct VideoTrimmerView: View {
             copyMode: copyMode
         )
 
-        // In a full implementation, this would invoke FFmpegProcessController
-        // with the arguments from VideoTrimmer.buildTrimArguments() or
-        // VideoTrimmer.buildSnipArguments(). For now, mark as complete.
+        let inputPath = file.fileURL.path
+        let outputDir = viewModel.outputDirectory ?? FileManager.default.temporaryDirectory
+        let baseName = PathSanitizer.sanitizeFilenameComponent(
+            file.fileURL.deletingPathExtension().lastPathComponent
+        )
+        let ext = file.fileURL.pathExtension.isEmpty ? "mp4" : file.fileURL.pathExtension
+        let sourceDuration = duration
+
+        applyTask = Task {
+            let ffmpegPath: String
+            do {
+                ffmpegPath = try await Task.detached {
+                    try FFmpegBundleManager().locateFFmpeg().path
+                }.value
+            } catch {
+                errorMessage = "FFmpeg could not be found. Install FFmpeg or configure its location in Settings before applying a trim."
+                isApplying = false
+                return
+            }
+
+            do {
+                // Split takes priority when configured, since FFmpeg's
+                // segment muxer (buildSplitArguments) operates on the whole
+                // input independently of trim/snip. Otherwise snip (which
+                // itself respects the trim head/tail via buildSnipArguments)
+                // runs when interior regions are marked; a plain head/tail
+                // trim is the fallback.
+                if config.splitBySize != nil || config.splitByChapters {
+                    let outputs = try await runSplit(
+                        ffmpegPath: ffmpegPath,
+                        inputPath: inputPath,
+                        outputDir: outputDir,
+                        config: config,
+                        duration: sourceDuration
+                    )
+                    successMessage = "Split complete. Wrote \(outputs.count) file(s) to \(outputDir.path)."
+                } else if !config.snipRegions.isEmpty {
+                    let output = try await runSnipAndConcat(
+                        ffmpegPath: ffmpegPath,
+                        inputPath: inputPath,
+                        outputDir: outputDir,
+                        baseName: baseName,
+                        ext: ext,
+                        config: config
+                    )
+                    successMessage = "Snip complete. Output written to \(output)."
+                } else {
+                    let output = try await runSimpleTrim(
+                        ffmpegPath: ffmpegPath,
+                        inputPath: inputPath,
+                        outputDir: outputDir,
+                        baseName: baseName,
+                        ext: ext,
+                        config: config
+                    )
+                    successMessage = "Trim complete. Output written to \(output)."
+                }
+            } catch is CancellationError {
+                // Cancelled by the user (or the view disappeared) — no
+                // success/error banner; cancelApply() already reset state.
+            } catch {
+                errorMessage = "Trim failed: \(error.localizedDescription)"
+            }
+
+            currentController = nil
+            isApplying = false
+        }
+    }
+
+    /// Cancel an in-progress Apply operation.
+    ///
+    /// Stops the currently-running FFmpeg process (if any) and cancels the
+    /// apply `Task` so no process or task is left running in the
+    /// background after the user navigates away from this view mid-trim.
+    private func cancelApply() {
+        currentController?.stopEncoding()
+        currentController = nil
+        applyTask?.cancel()
+        applyTask = nil
         isApplying = false
+    }
+
+    /// Runs a single FFmpeg pass to completion, honouring cancellation and
+    /// checking the real exit code — mirrors the pass-execution shape
+    /// proven in `QualityMetricsView.runAnalysis()`'s `passLoop`.
+    private func runToCompletion(
+        _ controller: FFmpegProcessController,
+        arguments: [String]
+    ) async throws {
+        let progressStream = try controller.startEncoding(arguments: arguments)
+        for await _ in progressStream {
+            if Task.isCancelled {
+                controller.stopEncoding()
+                break
+            }
+        }
+        if Task.isCancelled {
+            throw CancellationError()
+        }
+        if let code = controller.exitCode, code != 0 {
+            throw FFmpegProcessError.processFailure(exitCode: code, stderr: controller.errorOutput)
+        }
+    }
+
+    /// Runs a simple head/tail trim (`VideoTrimmer.buildTrimArguments`) and
+    /// returns the produced output path. Throws if FFmpeg exits non-zero or
+    /// no output file is actually written.
+    private func runSimpleTrim(
+        ffmpegPath: String,
+        inputPath: String,
+        outputDir: URL,
+        baseName: String,
+        ext: String,
+        config: TrimConfig
+    ) async throws -> String {
+        let outputPath = outputDir.appendingPathComponent(
+            PathSanitizer.sanitizeFilenameComponent("\(baseName)_trimmed.\(ext)")
+        ).path
+
+        let arguments = VideoTrimmer.buildTrimArguments(
+            inputPath: inputPath,
+            outputPath: outputPath,
+            config: config
+        )
+
+        let controller = FFmpegProcessController(binaryPath: ffmpegPath)
+        currentController = controller
+        try await runToCompletion(controller, arguments: arguments)
+
+        guard FileManager.default.fileExists(atPath: outputPath) else {
+            throw FFmpegProcessError.processFailure(
+                exitCode: controller.exitCode ?? -1,
+                stderr: "FFmpeg reported success but no output file was found at \(outputPath)."
+            )
+        }
+        return outputPath
+    }
+
+    /// Runs a snip operation: one `VideoTrimmer.buildSnipArguments` FFmpeg
+    /// pass per keep-segment (written to a scratch temp directory), then
+    /// joins the segments into the final output with
+    /// `VideoConcatenator.buildDemuxerConcatArguments`. The scratch segment
+    /// files and concat list are always removed afterwards, whether the
+    /// operation succeeds or fails.
+    private func runSnipAndConcat(
+        ffmpegPath: String,
+        inputPath: String,
+        outputDir: URL,
+        baseName: String,
+        ext: String,
+        config: TrimConfig
+    ) async throws -> String {
+        let scratchDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("trim_snip_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchDir) }
+
+        let segments = VideoTrimmer.buildSnipArguments(
+            inputPath: inputPath,
+            outputDir: scratchDir.path,
+            config: config
+        )
+        guard !segments.isEmpty else {
+            throw FFmpegProcessError.processFailure(
+                exitCode: -1,
+                stderr: "The configured trim/snip range leaves no content to keep."
+            )
+        }
+
+        for segment in segments {
+            if Task.isCancelled { throw CancellationError() }
+            let controller = FFmpegProcessController(binaryPath: ffmpegPath)
+            currentController = controller
+            try await runToCompletion(controller, arguments: segment.arguments)
+            guard FileManager.default.fileExists(atPath: segment.outputPath) else {
+                throw FFmpegProcessError.processFailure(
+                    exitCode: controller.exitCode ?? -1,
+                    stderr: "FFmpeg reported success but no segment file was found at \(segment.outputPath)."
+                )
+            }
+        }
+
+        let finalOutputPath = outputDir.appendingPathComponent(
+            PathSanitizer.sanitizeFilenameComponent("\(baseName)_trimmed.\(ext)")
+        ).path
+
+        let segmentURLs = segments.map { URL(fileURLWithPath: $0.outputPath) }
+        let (concatListContent, concatArgsTemplate) = VideoConcatenator.buildDemuxerConcatArguments(
+            files: segmentURLs,
+            outputPath: finalOutputPath
+        )
+
+        let listFileURL = scratchDir.appendingPathComponent("concat_list.txt")
+        try concatListContent.write(to: listFileURL, atomically: true, encoding: .utf8)
+
+        let concatArguments = concatArgsTemplate.map {
+            $0 == "<CONCAT_LIST_FILE>" ? listFileURL.path : $0
+        }
+
+        if Task.isCancelled { throw CancellationError() }
+        let concatController = FFmpegProcessController(binaryPath: ffmpegPath)
+        currentController = concatController
+        try await runToCompletion(concatController, arguments: concatArguments)
+
+        guard FileManager.default.fileExists(atPath: finalOutputPath) else {
+            throw FFmpegProcessError.processFailure(
+                exitCode: concatController.exitCode ?? -1,
+                stderr: "FFmpeg reported success but no output file was found at \(finalOutputPath)."
+            )
+        }
+        return finalOutputPath
+    }
+
+    /// Runs a size- or chapter-based split (`VideoTrimmer.buildSplitArguments`).
+    /// FFmpeg's segment muxer writes every output file from a single pass,
+    /// so this is one FFmpeg invocation; returns the paths of the files
+    /// actually found on disk matching the segment pattern.
+    private func runSplit(
+        ffmpegPath: String,
+        inputPath: String,
+        outputDir: URL,
+        config: TrimConfig,
+        duration: TimeInterval
+    ) async throws -> [String] {
+        let jobs = VideoTrimmer.buildSplitArguments(
+            inputPath: inputPath,
+            outputDir: outputDir.path,
+            config: config,
+            duration: duration
+        )
+        guard let job = jobs.first else {
+            throw FFmpegProcessError.processFailure(
+                exitCode: -1,
+                stderr: "No split configuration (chapters or max size) was set."
+            )
+        }
+
+        let controller = FFmpegProcessController(binaryPath: ffmpegPath)
+        currentController = controller
+        try await runToCompletion(controller, arguments: job.arguments)
+
+        // job.outputPath is a segment-muxer pattern such as
+        // ".../split_%03d.mp4" — resolve which files FFmpeg actually wrote
+        // by matching the literal prefix/suffix around "%03d".
+        let patternURL = URL(fileURLWithPath: job.outputPath)
+        let patternName = patternURL.lastPathComponent
+        let patternParts = patternName.components(separatedBy: "%03d")
+        let prefix = patternParts.first ?? patternName
+        let suffix = patternParts.count > 1 ? patternParts[1] : ""
+
+        let dirContents = (try? FileManager.default.contentsOfDirectory(
+            at: patternURL.deletingLastPathComponent(),
+            includingPropertiesForKeys: nil
+        )) ?? []
+        let written = dirContents
+            .filter { $0.lastPathComponent.hasPrefix(prefix) && $0.lastPathComponent.hasSuffix(suffix) }
+            .map(\.path)
+            .sorted()
+
+        guard !written.isEmpty else {
+            throw FFmpegProcessError.processFailure(
+                exitCode: controller.exitCode ?? -1,
+                stderr: "FFmpeg reported success but no split output files were found matching \(job.outputPath)."
+            )
+        }
+        return written
     }
 
     // MARK: - Formatting

--- a/Sources/MeedyaConverter/Views/VideoUploadView.swift
+++ b/Sources/MeedyaConverter/Views/VideoUploadView.swift
@@ -211,6 +211,10 @@ struct VideoUploadView: View {
                 .progressViewStyle(.linear)
             }
 
+            Text("Direct upload requires connecting a YouTube/Vimeo account (coming in a future update).")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
             HStack {
                 Spacer()
 
@@ -223,15 +227,16 @@ struct VideoUploadView: View {
                 }
 
                 Button("Upload") {
-                    startUpload()
+                    // TODO(#446): real OAuth2 upload — wire this to an
+                    // actual YouTube/Vimeo upload request once OAuth
+                    // credentials are available. Disabled for GA (v0.1.0)
+                    // rather than faking success (see the removed
+                    // `startUpload()` implementation this replaced, which
+                    // recorded `VideoUploadHistory(success: true)` without
+                    // ever sending anything).
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(
-                    !isAuthenticated
-                    || videoTitle.isEmpty
-                    || selectedFilePath.isEmpty
-                    || isUploading
-                )
+                .disabled(true)
             }
         }
     }
@@ -322,58 +327,13 @@ struct VideoUploadView: View {
         selectedFilePath = url.path
     }
 
-    /// Initiates the upload process.
-    ///
-    /// Builds the appropriate upload request and would normally send it
-    /// via URLSession. For now, records the attempt in history.
-    private func startUpload() {
-        let tags = tagsText
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-
-        let config = VideoUploadConfig(
-            service: selectedService,
-            title: videoTitle,
-            description: videoDescription,
-            tags: tags,
-            privacy: privacy,
-            accessToken: accessToken
-        )
-
-        let request: URLRequest?
-        switch selectedService {
-        case .youtube:
-            request = VideoUploader.buildYouTubeUploadRequest(
-                filePath: selectedFilePath,
-                config: config
-            )
-        case .vimeo:
-            request = VideoUploader.buildVimeoUploadRequest(
-                filePath: selectedFilePath,
-                config: config
-            )
-        }
-
-        guard request != nil else {
-            errorMessage = "Failed to build upload request. Check the file path and try again."
-            showError = true
-            return
-        }
-
-        isUploading = true
-        uploadProgress = 0
-
-        // Record in history (actual network upload would happen here).
-        let historyEntry = VideoUploadHistory(
-            filePath: selectedFilePath,
-            service: selectedService,
-            title: videoTitle,
-            success: true
-        )
-        uploadHistory.insert(historyEntry, at: 0)
-
-        // Simulate completion for now.
-        isUploading = false
-        uploadProgress = 1.0
-    }
+    // NOTE(#446): `startUpload()` used to live here. It built a real
+    // `URLRequest` via `VideoUploader.buildYouTubeUploadRequest`/
+    // `buildVimeoUploadRequest` but never sent it — it just unconditionally
+    // inserted `VideoUploadHistory(success: true)` into `uploadHistory`
+    // and flipped `isUploading` back off, fabricating a success entry for
+    // an upload that never happened. Real OAuth2 credentials are blocked
+    // on the maintainer (tracked in #446), so for the v0.1.0 GA the Upload
+    // button above is disabled and unwired instead of shipping a fake
+    // success path. See `// TODO(#446)` on the button action.
 }


### PR DESCRIPTION
## Summary

Fixes the "fabricated success" gaps that contradict the GA-readiness claim: UIs that reported success (or exported "PASS") for work that never ran. Each is now either **executed for real** or **honestly disabled** so nothing false is shown. Follows the proven `#433`/`#435`/`QualityMetricsView` execution + Swift 6 concurrency pattern (plain `@MainActor Task`; blocking calls isolated in `Task.detached{…}.value`).

## Changes Made

- [x] **#444** `VideoTrimmerView` — Apply now runs real trim / snip+concat / split via `FFmpegProcessController`, checks exit code + verifies output file, reports success only on real completion (was: built args then discarded them)
- [x] **#445** `QualityCheckView`/`QualityChecker` — runs real black-frame + silence detection; checks with no detector (audioSync, levelCompliance, corruptFrames, formatConformance) now report **Not Implemented**, never PASS; exported report tallies them separately (was: `passed: true` stubs exported as a QC report)
- [ ] **#447** `SFTP "Test Connection"` — real reachability+auth probe (in progress on this branch)
- [ ] **#446** `VideoUploadView` — honestly disable the upload control for GA (real YouTube/Vimeo OAuth tracked in #446; needs maintainer OAuth-app credentials) (in progress)
- [ ] **#449** `DuplicateFinder "Perceptual"` — disable the option for GA (real pHash tracked in #449) (in progress)

## Testing Done

Fresh CI on this branch is the gate — the fixes could not be compiled locally (macOS-only SwiftUI). Watch especially: `QCResult`'s new stored `status` + computed `passed` under Codable synthesis; the `VideoTrimmerView` split output-matching logic; Swift 6 concurrency correctness in the new `Task` flows.

- [ ] Build & Test (macOS)
- [ ] CodeQL / actionlint / pin-hygiene / dependency-review

## Related Issues

Fixes #444, #445; addresses #446, #447, #449.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NF44GLcMisedfvxHzhscJQ)_