### PR TITLE
Wire placeholder UIs to real engine: BitrateHeatmap, CloudSync, EncodingGraphs (#448)

### DIFF
--- a/Sources/MeedyaConverter/Views/BitrateHeatmapView.swift
+++ b/Sources/MeedyaConverter/Views/BitrateHeatmapView.swift
@@ -34,6 +34,11 @@ struct BitrateHeatmapView: View {
     @State private var showComparison = false
     @State private var errorMessage: String?
 
+    /// The in-flight analysis task, retained so it can be cancelled when
+    /// the user navigates away from this view mid-analysis. Mirrors
+    /// `LoudnessReportView.analysisTask` / `BenchmarkView.benchmarkTask`.
+    @State private var analysisTask: Task<Void, Never>?
+
     // MARK: - Body
 
     var body: some View {
@@ -53,6 +58,9 @@ struct BitrateHeatmapView: View {
             }
         }
         .navigationTitle("Bitrate Heatmap")
+        .onDisappear {
+            cancelAnalysis()
+        }
     }
 
     // MARK: - Toolbar
@@ -60,7 +68,7 @@ struct BitrateHeatmapView: View {
     private var toolbar: some View {
         HStack {
             Button {
-                Task { await analyzeBitrate() }
+                analysisTask = Task { await analyzeBitrate() }
             } label: {
                 Label("Analyze Bitrate", systemImage: "waveform.path.ecg")
             }
@@ -397,26 +405,88 @@ struct BitrateHeatmapView: View {
 
     /// Trigger bitrate analysis for the currently selected file.
     ///
-    /// Builds FFprobe arguments via ``BitrateAnalyzer``, but the actual
-    /// process execution is deferred to the view model or engine layer.
-    /// For now, we store the arguments for the caller to execute.
+    /// Builds FFprobe arguments via ``BitrateAnalyzer/buildAnalysisArguments(inputPath:)``,
+    /// actually runs them through the existing process runner —
+    /// `FFmpegBackendFactory.makeDefault().runFFprobe(arguments:timeout:)`
+    /// (`ProcessFFmpegBackend`/`FFmpegKitBackend` in `ConverterEngine`,
+    /// the same one-shot invocation surface documented for "new code" in
+    /// `FFmpegBackend.swift`) — and parses the resulting per-frame CSV
+    /// output with ``BitrateAnalyzer/parseProbeOutput(_:)`` to populate
+    /// the heatmap. No new ffprobe/parsing logic is introduced here.
+    ///
+    /// `BitrateHeatmapView` is a `struct: View`, so this `async` method
+    /// (and the plain `Task { }` that invokes it from the toolbar button)
+    /// is implicitly main-actor isolated via `View` conformance — `@State`
+    /// writes below are direct property mutations, matching
+    /// `QualityMetricsView.runAnalysis()`'s shape. `runFFprobe(...)`
+    /// itself is non-blocking (it suspends on a `CheckedContinuation`
+    /// while the process runs on background dispatch queues internally),
+    /// so it is awaited directly here without needing `Task.detached` —
+    /// the same reasoning `QualityMetricsView` applies to
+    /// `FFmpegProcessController.startEncoding`'s `AsyncStream`.
+    ///
+    /// Known limitation: `ProcessFFmpegBackend`'s one-shot `runFFprobe`
+    /// has no cancellation hook for an invocation already in flight (only
+    /// the streaming `runEncode` path supports `cancelCurrent()`), so
+    /// cancelling this task (via `cancelAnalysis()` / `onDisappear`) stops
+    /// this method from touching `@State` afterwards but does not itself
+    /// terminate an already-running ffprobe process early. Adding that
+    /// would require an `EncodingEngine`/`ConverterEngine` change, which
+    /// is out of scope here.
     private func analyzeBitrate() async {
         guard let file = viewModel.selectedFile else { return }
 
         isAnalyzing = true
         errorMessage = nil
 
-        // Build the ffprobe arguments (execution handled by engine)
         let args = BitrateAnalyzer.buildAnalysisArguments(inputPath: file.fileURL.path)
+        let backend = FFmpegBackendFactory.makeDefault()
 
-        // In a full implementation, the view model would execute ffprobe
-        // and return the output. For now we log the intent.
-        viewModel.appendLog(
-            .info,
-            "Bitrate analysis requested for \(file.fileName) with \(args.count) arguments",
-            category: .general
-        )
+        do {
+            let result = try await backend.runFFprobe(arguments: args, timeout: 300)
 
+            if Task.isCancelled {
+                isAnalyzing = false
+                return
+            }
+
+            let parsed = BitrateAnalyzer.parseProbeOutput(result.stdout)
+            guard !parsed.dataPoints.isEmpty else {
+                errorMessage = "FFprobe returned no readable bitrate data for \(file.fileName)."
+                isAnalyzing = false
+                return
+            }
+
+            analysis = parsed
+            viewModel.appendLog(
+                .info,
+                "Bitrate analysis complete for \(file.fileName): \(parsed.dataPoints.count) data point(s), "
+                + "average \(Int(parsed.averageBitrate)) bps, peak \(Int(parsed.peakBitrate)) bps",
+                category: .general
+            )
+        } catch {
+            if !Task.isCancelled {
+                errorMessage = "Bitrate analysis failed for \(file.fileName): \(error.localizedDescription)"
+                viewModel.appendLog(
+                    .error,
+                    "Bitrate analysis failed for \(file.fileName): \(error.localizedDescription)",
+                    category: .general
+                )
+            }
+        }
+
+        isAnalyzing = false
+    }
+
+    /// Cancel an in-progress bitrate analysis.
+    ///
+    /// Cancels the analysis `Task` so no pending state mutation runs
+    /// after the user navigates away from this view. See the known
+    /// limitation noted on `analyzeBitrate()`: the underlying ffprobe
+    /// process itself is not forcibly terminated by this call.
+    private func cancelAnalysis() {
+        analysisTask?.cancel()
+        analysisTask = nil
         isAnalyzing = false
     }
 

--- a/Sources/MeedyaConverter/Views/CloudSyncView.swift
+++ b/Sources/MeedyaConverter/Views/CloudSyncView.swift
@@ -70,6 +70,11 @@ struct CloudSyncView: View {
     /// Number of profiles downloaded in the last sync.
     @State private var lastDownloadCount: Int = 0
 
+    /// The in-flight upload/download task, retained so it can be
+    /// cancelled if the user dismisses this view mid-sync. Mirrors
+    /// `LoudnessReportView.analysisTask` / `BenchmarkView.benchmarkTask`.
+    @State private var syncTask: Task<Void, Never>?
+
     // MARK: - Body
 
     var body: some View {
@@ -89,6 +94,10 @@ struct CloudSyncView: View {
         }
         .onAppear {
             refreshState()
+        }
+        .onDisappear {
+            syncTask?.cancel()
+            syncTask = nil
         }
         .alert("Sync Error", isPresented: $showError) {
             Button("OK") {}
@@ -175,7 +184,7 @@ struct CloudSyncView: View {
         Section("Manual Sync") {
             HStack {
                 Button {
-                    performUpload()
+                    syncTask = Task { await performUpload() }
                 } label: {
                     Label("Upload Profiles", systemImage: "arrow.up.circle")
                 }
@@ -184,7 +193,7 @@ struct CloudSyncView: View {
                 Spacer()
 
                 Button {
-                    performDownload()
+                    syncTask = Task { await performDownload() }
                 } label: {
                     Label("Download Profiles", systemImage: "arrow.down.circle")
                 }
@@ -312,33 +321,104 @@ struct CloudSyncView: View {
     }
 
     /// Uploads local profiles to iCloud.
-    private func performUpload() {
+    ///
+    /// Mirrors `TeamProfileView.pushProfiles()` (see
+    /// `TeamProfileView.swift` around line 268): pulls the live profile
+    /// list from the shared `EncodingProfileStore`
+    /// (`viewModel.engine.profileStore.profiles`) instead of the
+    /// previous hardcoded empty array, so `lastUploadCount` reflects the
+    /// number of profiles genuinely written to iCloud.
+    ///
+    /// `CloudSyncView` is a `struct: View`, so this `async` method (and
+    /// the plain `Task { }` that calls it from the button) is implicitly
+    /// main-actor isolated via `View` conformance — `@State` writes below
+    /// are direct property mutations, matching
+    /// `QualityMetricsView.runAnalysis()`'s shape.
+    /// `CloudProfileSync.uploadProfiles(_:)` performs genuinely blocking
+    /// file I/O against the iCloud ubiquity container, so it runs inside
+    /// `Task.detached`, capturing/returning only `Sendable` values
+    /// (`syncManager` is `@unchecked Sendable`; `[EncodingProfile]` is
+    /// `Sendable`) and never touching `self`/`@State` directly — mirroring
+    /// how `QualityMetricsView.runAnalysis()` detaches
+    /// `FFmpegBundleManager.locateFFmpeg()`.
+    private func performUpload() async {
         isSyncing = true
-        // In a full implementation, fetch profiles from the profile manager.
-        // For now, demonstrate the API.
+        errorMessage = nil
+        lastUploadCount = 0
+
+        let profiles = viewModel.engine.profileStore.profiles
+        let manager = syncManager
+
         do {
-            let profiles: [EncodingProfile] = []  // Would be fetched from profile store.
-            try syncManager.uploadProfiles(profiles)
+            try await Task.detached {
+                try manager.uploadProfiles(profiles)
+            }.value
+
+            guard !Task.isCancelled else {
+                isSyncing = false
+                return
+            }
             lastUploadCount = profiles.count
         } catch {
-            errorMessage = error.localizedDescription
-            showError = true
+            if !Task.isCancelled {
+                errorMessage = error.localizedDescription
+                showError = true
+            }
         }
+
         isSyncing = false
         refreshState()
     }
 
-    /// Downloads profiles from iCloud.
-    private func performDownload() {
+    /// Downloads profiles from iCloud and merges them into the local
+    /// profile store.
+    ///
+    /// Profiles already known locally (matched by ID) are updated in
+    /// place via `EncodingProfileStore.updateProfile(_:)`; profiles not
+    /// yet seen locally are added via `addProfile(_:)`. This reuses the
+    /// store's existing CRUD surface (the same one `ProfileManagementView`
+    /// and `TeamProfileView` exercise) rather than inventing new merge
+    /// logic, and makes `lastDownloadCount` reflect real merged profiles
+    /// instead of a discarded result.
+    ///
+    /// Concurrency shape mirrors `performUpload()` above:
+    /// `CloudProfileSync.downloadProfiles()` blocks on file I/O, so it
+    /// runs inside `Task.detached`; the merge into `profileStore` happens
+    /// back on the main actor once the detached call returns, alongside
+    /// the other `@State` writes.
+    private func performDownload() async {
         isSyncing = true
+        errorMessage = nil
+        lastDownloadCount = 0
+
+        let manager = syncManager
+
         do {
-            let profiles = try syncManager.downloadProfiles()
-            lastDownloadCount = profiles.count
-            // In a full implementation, merge into local profile store.
+            let downloaded = try await Task.detached {
+                try manager.downloadProfiles()
+            }.value
+
+            guard !Task.isCancelled else {
+                isSyncing = false
+                return
+            }
+
+            let store = viewModel.engine.profileStore
+            for profile in downloaded {
+                if store.profile(id: profile.id) != nil {
+                    store.updateProfile(profile)
+                } else {
+                    store.addProfile(profile)
+                }
+            }
+            lastDownloadCount = downloaded.count
         } catch {
-            errorMessage = error.localizedDescription
-            showError = true
+            if !Task.isCancelled {
+                errorMessage = error.localizedDescription
+                showError = true
+            }
         }
+
         isSyncing = false
         refreshState()
     }

--- a/Sources/MeedyaConverter/Views/EncodingGraphsView.swift
+++ b/Sources/MeedyaConverter/Views/EncodingGraphsView.swift
@@ -61,6 +61,13 @@ struct EncodingGraphsView: View {
     @State private var selectedMetric: GraphMetric = .fps
     @State private var selectedJobID: UUID?
 
+    /// Persisted history of completed encoding job statistics, backing
+    /// the graphs below. Real, already-tested component
+    /// (`EncodingStatisticsStore` in `ConverterEngine`) — reads its JSON
+    /// history from disk in its initializer, the same way `CloudSyncView`
+    /// seeds its `@State` directly from `CloudProfileSync.shared`.
+    @State private var statisticsStore = EncodingStatisticsStore()
+
     // MARK: - Body
 
     var body: some View {
@@ -85,6 +92,25 @@ struct EncodingGraphsView: View {
             }
         }
         .navigationTitle("Encoding Graphs")
+        .onAppear {
+            // Reload from disk each time this view appears so a job
+            // completed since the store was last constructed shows up.
+            // `EncodingStatisticsStore` only reads its history file inside
+            // `init()`, so a fresh instance is how a re-read happens.
+            // `EncodingStatisticsStore` is `@unchecked Sendable`, so the
+            // (potentially non-trivial) JSON decode of the history file is
+            // kept off the main actor via `Task.detached`, mirroring
+            // `QualityMetricsView.runAnalysis()`'s handling of
+            // `FFmpegBundleManager.locateFFmpeg()` — this `Task { }` itself
+            // is created from a `View` body closure, so it inherits
+            // main-actor isolation and the assignment below is a direct
+            // `@State` write, not a `MainActor.run` hop.
+            Task {
+                statisticsStore = await Task.detached {
+                    EncodingStatisticsStore()
+                }.value
+            }
+        }
     }
 
     // MARK: - Subviews
@@ -289,10 +315,18 @@ struct EncodingGraphsView: View {
 
     // MARK: - Helpers
 
+    /// The statistics currently displayed: the history entry matching
+    /// `selectedJobID` if one is set, otherwise the most recently
+    /// completed job. Real data sourced from `EncodingStatisticsStore`
+    /// (`ConverterEngine`) — `nil` (driving `emptyStateView` above) is an
+    /// honest reflection of "no encode has been recorded yet", not a
+    /// placeholder.
     private var currentStatistics: EncodingStatistics? {
-        // Placeholder — in a real implementation this would come from
-        // the active job's statistics collector or the history store
-        nil
+        let history = statisticsStore.allStatistics
+        if let selectedJobID {
+            return history.first { $0.jobID == selectedJobID }
+        }
+        return history.first
     }
 
     private func formatDuration(_ seconds: TimeInterval) -> String {


### PR DESCRIPTION
## Summary

Wires three of the placeholder UIs from #448 to their real, already-existing engine components (no fabricated success). Follows the proven execution + Swift 6 concurrency pattern.

## Changes Made

- [x] **`BitrateHeatmapView`** — now runs the built ffprobe args for real via `FFmpegBackendFactory.makeDefault().runFFprobe(...)` and parses with `BitrateAnalyzer.parseProbeOutput`, populating the heatmap; honest error on failure (was: built args, logged "requested", never executed)
- [x] **`CloudSyncView`** — upload now reads the real `profileStore.profiles`; download merges returned profiles back into the store via existing CRUD; real success/error counts (was: uploaded an empty array and reported success)
- [x] **`EncodingGraphsView`** — reads the real `EncodingStatisticsStore` (was: `currentStatistics` hardcoded `nil`). ⚠️ Honest partial: the store's **write-side (`EncodingStatisticsCollector`) is not yet invoked by the encode pipeline** (that wiring lives in `EncodingEngine`/`AppViewModel`, outside this PR's scope), so the view now shows an honest empty state and will auto-populate once the collector is wired — tracked as a follow-up.

## Testing Done

Fresh CI is the gate (macOS-only, not locally buildable). Watch: `FFmpegBackendFactory.runFFprobe` is used from a GUI view for the first time here.

- [ ] Build & Test (macOS)
- [ ] CodeQL / pin-hygiene / actionlint / dependency-review

## Related Issues

Addresses #448 (3 of 5 views wired). Remaining under #448: `DualDynamicHDRView` (needs DoviTool/HDR10Plus wrappers) + wiring `EncodingStatisticsCollector` into the encode pipeline (engine change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NF44GLcMisedfvxHzhscJQ)_