### PR TITLE
Wire SFTP post-encode action to real scp upload; honestly gate cloud (#450)

### DIFF
--- a/Sources/ConverterEngine/Cloud/SFTPUploader.swift
+++ b/Sources/ConverterEngine/Cloud/SFTPUploader.swift
@@ -503,3 +503,209 @@ public struct SFTPUploader: Sendable {
         return args
     }
 }
+
+// MARK: - SFTPUploadOutcome
+
+/// The real outcome of an `scp` upload attempt.
+///
+/// Mirrors `SFTPSettingsView.ConnectionProbeResult` (Issue #447) one
+/// layer down, in `ConverterEngine`, so callers such as
+/// `PostEncodeActionChain` (Issue #450) get the same honest-failure
+/// guarantee — success/failure/message are always what `scp` actually
+/// reported, never fabricated.
+public struct SFTPUploadOutcome: Sendable {
+    /// Whether `scp` exited with status 0.
+    public let succeeded: Bool
+
+    /// A human-readable success confirmation, or the real error `scp`
+    /// reported (its stderr output, or a process-launch failure
+    /// description).
+    public let message: String
+
+    public init(succeeded: Bool, message: String) {
+        self.succeeded = succeeded
+        self.message = message
+    }
+}
+
+// MARK: - SFTPUploader Execution
+
+extension SFTPUploader {
+
+    /// Uploads `localPath` to the server described by `config` via `scp`,
+    /// blocking the calling thread until the transfer finishes or fails.
+    ///
+    /// This is a **blocking** call — the caller MUST run it off the
+    /// main/calling actor (e.g. via `Task.detached`), exactly as
+    /// `SFTPSettingsView.probeConnection(config:)` does for connection
+    /// tests (Issue #447). It is marked `nonisolated` to document that it
+    /// touches no actor-isolated state; hopping off-actor before invoking
+    /// it remains the caller's responsibility.
+    ///
+    /// Credential handling reuses `buildSCPArguments(localPath:config:)`
+    /// as-is — nothing new is added to argv, so key-file paths and
+    /// hostnames are the only configuration data that ever appears in
+    /// process arguments. A password-based profile is a documented
+    /// exception: `-o BatchMode=yes` is prepended ahead of the builder's
+    /// own `-o BatchMode=no` for `.password` configs so `scp` can never
+    /// block on a password prompt with no controlling terminal to read it
+    /// from. Per `ssh_config(5)`, the first value supplied for a given
+    /// `-o` key wins, so the prepended flag takes precedence — the same
+    /// technique `SFTPSettingsView.probeConnection` already uses and
+    /// documents. A password-only profile therefore fails fast with
+    /// `scp`'s real "Permission denied" error rather than hanging; that
+    /// is a genuine SSH-protocol limitation (no non-interactive way to
+    /// submit a plaintext password), not a fabricated failure. Key-file
+    /// and SSH-agent authentication are unaffected and upload normally.
+    ///
+    /// - Parameters:
+    ///   - localPath: Absolute path to the file to upload.
+    ///   - config: The destination SFTP server configuration.
+    /// - Returns: The real `scp` outcome — never a fabricated success.
+    public nonisolated static func upload(
+        localPath: String,
+        config: SFTPServerConfig
+    ) -> SFTPUploadOutcome {
+        var args = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=15"]
+        args.append(contentsOf: buildSCPArguments(localPath: localPath, config: config))
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/scp")
+        process.arguments = args
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+        process.standardInput = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return SFTPUploadOutcome(
+                succeeded: false,
+                message: "Could not launch scp: \(error.localizedDescription)"
+            )
+        }
+
+        // Drain both pipes concurrently so a chatty remote (e.g. a login
+        // banner/MOTD written to stdout) can't fill the pipe buffer and
+        // deadlock `waitUntilExit()` — the same pitfall documented at
+        // `SFTPSettingsView.probeConnection` and `FFmpegProbe.runFFprobe`.
+        let ioState = SFTPUploadIOState()
+        let stdoutDone = DispatchSemaphore(value: 0)
+        let stderrDone = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global(qos: .utility).async {
+            ioState.stdout = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            stdoutDone.signal()
+        }
+        DispatchQueue.global(qos: .utility).async {
+            ioState.stderr = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            stderrDone.signal()
+        }
+
+        process.waitUntilExit()
+        stdoutDone.wait()
+        stderrDone.wait()
+
+        guard process.terminationStatus == 0 else {
+            let stderrText = String(data: ioState.stderr, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let detail = stderrText.isEmpty
+                ? "scp exited with status \(process.terminationStatus)."
+                : stderrText
+            return SFTPUploadOutcome(succeeded: false, message: detail)
+        }
+
+        return SFTPUploadOutcome(
+            succeeded: true,
+            message: "Uploaded to \(config.username)@\(config.host):\(config.remotePath)"
+        )
+    }
+}
+
+// MARK: - SFTPUploadIOState
+
+/// Holds the drained stdout/stderr bytes from `SFTPUploader.upload`'s
+/// `scp` invocation.
+///
+/// `@unchecked Sendable`: the two background readers each own a
+/// disjoint property (`stdout`/`stderr`) and `upload` only reads them
+/// after waiting on the `DispatchSemaphore` each reader signals on
+/// completion, so the semaphore hand-off — not the compiler —
+/// establishes the happens-before relationship. Mirrors
+/// `SFTPSettingsView.ProbeIOState`, which does the equivalent job for
+/// the connection-test probe.
+private final class SFTPUploadIOState: @unchecked Sendable {
+    var stdout = Data()
+    var stderr = Data()
+}
+
+// MARK: - SFTPProfileStore
+
+/// Read-only access to the SFTP server profiles saved by
+/// `SFTPSettingsView` (Issue #312), for consumers outside the app's
+/// SwiftUI layer — e.g. `PostEncodeActionChain` (Issue #450), which runs
+/// inside `ConverterEngine` and has no view to bind form state to.
+///
+/// This intentionally does not duplicate storage: it reads the exact
+/// same `UserDefaults` blob and the exact same `SFTPCredentialStore`
+/// Keychain entries that `SFTPSettingsView.loadProfiles()` /
+/// `persistProfiles()` already own. There is a single source of truth
+/// for "what SFTP servers has the user configured" — this type just
+/// gives non-UI code a way to read it.
+public enum SFTPProfileStore {
+
+    /// `UserDefaults` key under which the redacted profile array lives.
+    /// Shared with `SFTPSettingsView` so the storage key cannot drift
+    /// between the write side (settings UI) and this read side.
+    public static let userDefaultsKey = "sftpProfiles"
+
+    /// Loads every saved SFTP profile, restoring each profile's
+    /// plaintext password (if any) from the Keychain via
+    /// `SFTPCredentialStore`.
+    ///
+    /// Read-only: unlike `SFTPSettingsView.loadProfiles()`, this never
+    /// rewrites `UserDefaults` — the legacy-plaintext-blob migration
+    /// (SECURITY.md F-005) remains the settings view's responsibility.
+    /// A profile whose Keychain lookup fails (deleted out of band, no
+    /// entry yet, etc.) is returned with its password left as stored
+    /// (typically empty); callers should treat that as "credential
+    /// unavailable" rather than assume it will authenticate.
+    ///
+    /// - Returns: The saved profiles, or an empty array if none are
+    ///   saved or the stored JSON cannot be decoded.
+    public static func loadProfiles() -> [SFTPServerConfig] {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let profiles = try? JSONDecoder().decode(
+                  [SFTPServerConfig].self, from: data
+              ) else {
+            return []
+        }
+
+        return profiles.map { profile in
+            guard case .password(let storedPassword) = profile.authMethod,
+                  storedPassword.isEmpty else {
+                return profile
+            }
+            guard let realPassword = try? SFTPCredentialStore.read(forProfileID: profile.id),
+                  !realPassword.isEmpty else {
+                return profile
+            }
+            var copy = profile
+            copy.authMethod = .password(realPassword)
+            return copy
+        }
+    }
+
+    /// Looks up a single saved profile by its stable `id`.
+    ///
+    /// - Parameter id: The profile's `SFTPServerConfig.id`.
+    /// - Returns: The matching profile (with its password restored from
+    ///   the Keychain when applicable), or `nil` if no profile with that
+    ///   id is currently saved.
+    public static func profile(withID id: UUID) -> SFTPServerConfig? {
+        loadProfiles().first { $0.id == id }
+    }
+}

--- a/Sources/ConverterEngine/Encoding/PostEncodeActions.swift
+++ b/Sources/ConverterEngine/Encoding/PostEncodeActions.swift
@@ -15,8 +15,9 @@ import AppKit
 /// The type of action to execute after an encoding job completes.
 ///
 /// Actions run in the order they appear in a `PostEncodeActionChain`.
-/// Some types (`.uploadSFTP`, `.uploadCloud`) are reserved for future
-/// implementation and currently throw an "unsupported" error if executed.
+/// `.uploadCloud` remains reserved for future implementation and
+/// currently throws an "unsupported" error if executed — see its doc
+/// comment for why (Issue #450).
 public enum PostEncodeActionType: String, Codable, Sendable, CaseIterable {
     /// Move the source file to the macOS Trash.
     case moveSourceToTrash
@@ -32,10 +33,19 @@ public enum PostEncodeActionType: String, Codable, Sendable, CaseIterable {
     /// Send a webhook POST request (delegates to `WebhookSender`).
     case webhook
 
-    /// Upload the output file via SFTP (future — not yet implemented).
+    /// Upload the output file via SFTP/`scp`, using a server profile saved
+    /// in `SFTPSettingsView` and looked up through `SFTPProfileStore`
+    /// (Issue #450). See `PostEncodeAction.config` for the expected key.
     case uploadSFTP
 
-    /// Upload the output file to cloud storage (future — not yet implemented).
+    /// Upload the output file to cloud storage (future — not yet
+    /// implemented). `CloudStorageUploader` / `VideoUploader` /
+    /// `S3Uploader` only build `URLRequest`s / argument lists for a
+    /// hand-entered OAuth token — nothing in this codebase actually
+    /// executes an authenticated network upload of file bytes for any
+    /// cloud provider, so there is no real API yet for this action to
+    /// call. Wiring this honestly requires that execution path to exist
+    /// first (tracked separately from Issue #450).
     case uploadCloud
 
     /// Send a macOS notification with a custom message.
@@ -72,6 +82,11 @@ public struct PostEncodeAction: Identifiable, Codable, Sendable {
     /// - `.webhook`: `"url"` — the webhook endpoint URL.
     /// - `.sendNotification`: `"message"` — the notification body text.
     /// - `.sendNotification`: `"title"` — optional notification title.
+    /// - `.uploadSFTP`: `"sftpProfileID"` — the `UUID` string of a saved
+    ///   `SFTPServerConfig` profile (see `SFTPSettingsView` /
+    ///   `SFTPProfileStore`). No credentials are ever stored here —
+    ///   only a reference to a profile whose secret lives in the
+    ///   Keychain via `SFTPCredentialStore`.
     public var config: [String: String]
 
     /// Whether this action is enabled. Disabled actions are skipped.
@@ -152,15 +167,30 @@ public struct PostEncodeActionChain: Codable, Sendable {
         case unsupportedAction(PostEncodeActionType)
         /// A required configuration key is missing.
         case missingConfig(key: String, actionName: String)
+        /// A configured upload (SFTP/cloud) genuinely failed. Carries the
+        /// real error the uploader reported — never a fabricated one.
+        case uploadFailed(actionName: String, message: String)
 
         public var errorDescription: String? {
             switch self {
             case .shellScriptFailed(let code, let output):
                 return "Shell script exited with code \(code): \(output)"
             case .unsupportedAction(let type):
-                return "Action type '\(type.rawValue)' is not yet supported."
+                switch type {
+                case .uploadCloud:
+                    return "Action type 'uploadCloud' requires cloud-upload execution "
+                        + "support (OAuth token exchange + authenticated file transfer) "
+                        + "that does not exist yet in this codebase — only "
+                        + "request-builder helpers (CloudStorageUploader, VideoUploader, "
+                        + "S3Uploader) are implemented, not real execution. Not "
+                        + "implemented (Issue #450)."
+                default:
+                    return "Action type '\(type.rawValue)' is not yet supported."
+                }
             case .missingConfig(let key, let name):
                 return "Action '\(name)' is missing required config key '\(key)'."
+            case .uploadFailed(let name, let message):
+                return "Action '\(name)' upload failed: \(message)"
             }
         }
     }
@@ -271,9 +301,14 @@ public struct PostEncodeActionChain: Codable, Sendable {
             await sendMacOSNotification(title: title, body: substituted)
 
         case .uploadSFTP:
-            throw ActionError.unsupportedAction(.uploadSFTP)
+            try await uploadViaSFTP(action: action, outputURL: outputURL)
 
         case .uploadCloud:
+            // Honest "not implemented" — see the doc comment on
+            // `PostEncodeActionType.uploadCloud` and Issue #450: no
+            // component in this codebase actually executes an
+            // authenticated cloud upload, so there is nothing real to
+            // wire this to yet.
             throw ActionError.unsupportedAction(.uploadCloud)
         }
     }
@@ -319,6 +354,48 @@ public struct PostEncodeActionChain: Codable, Sendable {
     /// - Parameter inputURL: The source file URL.
     private func moveToTrash(inputURL: URL) async throws {
         try FileManager.default.trashItem(at: inputURL, resultingItemURL: nil)
+    }
+
+    /// Upload the encoded output file to a saved SFTP server profile via
+    /// `scp`.
+    ///
+    /// Reuses the existing uploader plumbing end to end rather than
+    /// inventing a parallel path:
+    /// - `action.config["sftpProfileID"]` resolves to a profile through
+    ///   `SFTPProfileStore.profile(withID:)`, which reads the exact same
+    ///   `UserDefaults` blob `SFTPSettingsView` writes and restores the
+    ///   password (if any) from the Keychain via `SFTPCredentialStore` —
+    ///   no credential is ever stored inside `PostEncodeAction.config`.
+    /// - `SFTPUploader.upload(localPath:config:)` builds argv with
+    ///   `SFTPUploader.buildSCPArguments(localPath:config:)` (unchanged —
+    ///   credentials never touch argv) and runs `scp`.
+    ///
+    /// Concurrency mirrors `SFTPSettingsView.probeConnection` (Issue
+    /// #447): the blocking `scp`/`waitUntilExit()` work happens inside
+    /// `Task.detached`, capturing and returning only `Sendable` values
+    /// (`SFTPServerConfig` in, `SFTPUploadOutcome` out) — never `self`.
+    ///
+    /// - Parameters:
+    ///   - action: The configured `.uploadSFTP` action.
+    ///   - outputURL: The encoded output file to upload.
+    /// - Throws: `ActionError.missingConfig` if no valid profile
+    ///   reference is configured, or `ActionError.uploadFailed` with the
+    ///   real `scp` error if the transfer fails.
+    private func uploadViaSFTP(action: PostEncodeAction, outputURL: URL) async throws {
+        guard let profileIDString = action.config["sftpProfileID"],
+              let profileID = UUID(uuidString: profileIDString),
+              let profile = SFTPProfileStore.profile(withID: profileID) else {
+            throw ActionError.missingConfig(key: "sftpProfileID", actionName: action.name)
+        }
+
+        let localPath = outputURL.path
+        let outcome = await Task.detached {
+            SFTPUploader.upload(localPath: localPath, config: profile)
+        }.value
+
+        guard outcome.succeeded else {
+            throw ActionError.uploadFailed(actionName: action.name, message: outcome.message)
+        }
     }
 
     /// Reveal the output file in Finder.

--- a/Sources/MeedyaConverter/Views/PostEncodeActionsView.swift
+++ b/Sources/MeedyaConverter/Views/PostEncodeActionsView.swift
@@ -305,8 +305,36 @@ struct PostEncodeActionRow: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-        case .uploadSFTP, .uploadCloud:
-            Text("This action type is not yet available.")
+        case .uploadSFTP:
+            let profiles = SFTPProfileStore.loadProfiles()
+            if profiles.isEmpty {
+                Text("No saved SFTP servers. Add one in Settings → SFTP, then pick it here.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            } else {
+                Picker(
+                    "SFTP Server",
+                    selection: Binding(
+                        get: { action.config["sftpProfileID"] ?? "" },
+                        set: { action.config["sftpProfileID"] = $0 }
+                    )
+                ) {
+                    Text("Select a server…").tag("")
+                    ForEach(profiles, id: \.id) { profile in
+                        Text("\(profile.label) (\(profile.host))").tag(profile.id.uuidString)
+                    }
+                }
+                .accessibilityLabel("SFTP server profile")
+
+                Text("Uploads the encoded output file via scp to the selected server.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+        case .uploadCloud:
+            Text("Cloud upload is not yet available: no component in this app performs an "
+                + "authenticated upload to Dropbox, OneDrive, Google Drive, S3, YouTube, or "
+                + "Vimeo — only the request-builder helpers exist. Use SFTP upload instead.")
                 .font(.caption)
                 .foregroundStyle(.orange)
         }
@@ -397,8 +425,8 @@ struct AddActionSheet: View {
         case .openInFinder: return "Reveal in Finder"
         case .runShellScript: return "Run Shell Script"
         case .webhook: return "Send Webhook"
-        case .uploadSFTP: return "Upload via SFTP (Future)"
-        case .uploadCloud: return "Upload to Cloud (Future)"
+        case .uploadSFTP: return "Upload via SFTP"
+        case .uploadCloud: return "Upload to Cloud (Not Yet Available)"
         case .sendNotification: return "Send Notification"
         }
     }

--- a/Sources/MeedyaConverter/Views/SFTPSettingsView.swift
+++ b/Sources/MeedyaConverter/Views/SFTPSettingsView.swift
@@ -495,9 +495,10 @@ struct SFTPSettingsView: View {
     // MARK: - Persistence
 
     /// UserDefaults key under which the redacted profile array lives.
-    /// String literal kept in a `Self.` constant so the load / persist
-    /// pair cannot drift.
-    private static let userDefaultsKey = "sftpProfiles"
+    /// Sourced from `SFTPProfileStore.userDefaultsKey` (Issue #450) so
+    /// this view and the read-only `SFTPProfileStore` used by
+    /// `PostEncodeActionChain` can never drift onto different keys.
+    private static let userDefaultsKey = SFTPProfileStore.userDefaultsKey
 
     /// Loads saved profiles from UserDefaults and restores their
     /// passwords from the Keychain.


### PR DESCRIPTION
## Summary

Implements the **SFTP** post-encode action (#450) and honestly gates the **cloud** one.

- **SFTP** now performs a real `scp` upload via the existing (unchanged) `SFTPUploader.buildSCPArguments` + `SFTPCredentialStore` (Keychain), through a new `nonisolated SFTPUploader.upload(...)` and a read-only `SFTPProfileStore` over the same `"sftpProfiles"` UserDefaults + Keychain that `SFTPSettingsView` already owns. The action config stores only a **profile UUID** (never credentials); the secret is fetched from Keychain at execution. Credentials never touch argv; `BatchMode=yes`+`ConnectTimeout=15` (same discipline as the #447 probe).
- **Cloud** upload is left throwing — with an honest, specific message — because **no cloud uploader in the repo executes a real upload** (see finding below), so there's nothing to wire it to.

## Changes Made

- [x] `PostEncodeActions.uploadSFTP` → real `scp` upload; new `ActionError.uploadFailed`
- [x] `SFTPUploader` → new `nonisolated upload()` + `SFTPProfileStore`; existing code untouched
- [x] `PostEncodeActionsView` → SFTP action enabled with a saved-profile `Picker`
- [x] `uploadCloud` → honest "no execution API" gating (not fabricated success)
- [x] `SFTPSettingsView` → single source of truth for the storage key

## ⚠️ Finding (flagging, not fixing here)

`S3Uploader`, `CloudStorageUploader`, and `VideoUploader` **only build `URLRequest`s and never send them** — the entire "cloud upload" capability (the product's "12+ cloud providers") appears non-functional at the execution layer. This is the same fabrication class as #446/#448 but broader. Recommend a dedicated issue.

## Testing Done

CI is the gate (macOS-only, not locally buildable). Watch the new `SFTPUploader`/`PostEncodeActions`/`PostEncodeActionsView` additions. No tests added (none existed for `PostEncodeActions`; flagged for follow-up).

## Related Issues

Addresses #450 (SFTP done; cloud blocked on a missing uploader-execution layer).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NF44GLcMisedfvxHzhscJQ)_