### PR TITLE
Cloud-upload execution layer: CloudUploadExecutor + token providers + post-encode (#459, #450)

### DIFF
--- a/Sources/ConverterEngine/Cloud/CloudStorageUploader.swift
+++ b/Sources/ConverterEngine/Cloud/CloudStorageUploader.swift
@@ -119,10 +119,9 @@ public struct CloudStorageUploader: Sendable {
             return nil
         }
 
-        let fileName = (filePath as NSString).lastPathComponent
         let remoteDest = config.remotePath.hasSuffix("/")
-            ? config.remotePath + fileName
-            : config.remotePath + "/" + fileName
+            ? config.remotePath + filePath
+            : config.remotePath + "/" + filePath
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"

--- a/Sources/ConverterEngine/Cloud/CloudStorageUploader.swift
+++ b/Sources/ConverterEngine/Cloud/CloudStorageUploader.swift
@@ -35,6 +35,17 @@ public enum CloudStorageProvider: String, Codable, Sendable, CaseIterable {
 /// so the user can have multiple upload targets.
 public struct CloudStorageConfig: Codable, Sendable {
 
+    /// Stable identifier for this configuration, generated fresh by the
+    /// default init and preserved across load/save cycles so
+    /// `CloudStorageProfileStore` (Issue #459) — and
+    /// `PostEncodeActionChain.uploadViaCloud`, which resolves a saved
+    /// configuration by this id — stay addressable across app
+    /// launches. Added alongside the #459 execution layer; no prior
+    /// on-disk `CloudStorageConfig` data exists to migrate (before
+    /// #459 `CloudStorageView` never persisted `savedConfigs` at all —
+    /// see `CloudStorageProfileStore`'s doc comment).
+    public var id: UUID
+
     /// The cloud storage provider.
     public var provider: CloudStorageProvider
 
@@ -53,18 +64,21 @@ public struct CloudStorageConfig: Codable, Sendable {
     /// Creates a new cloud storage configuration.
     ///
     /// - Parameters:
+    ///   - id: Stable identifier (defaults to a fresh `UUID()`).
     ///   - provider: The cloud storage provider.
     ///   - accessToken: The OAuth 2.0 access token.
     ///   - refreshToken: An optional refresh token.
     ///   - remotePath: The remote folder path for uploads.
     ///   - label: A user-facing label for this configuration.
     public init(
+        id: UUID = UUID(),
         provider: CloudStorageProvider,
         accessToken: String,
         refreshToken: String? = nil,
         remotePath: String,
         label: String
     ) {
+        self.id = id
         self.provider = provider
         self.accessToken = accessToken
         self.refreshToken = refreshToken
@@ -169,6 +183,56 @@ public struct CloudStorageUploader: Sendable {
         return request
     }
 
+    /// Build a Microsoft Graph API "create upload session" request for
+    /// OneDrive large-file uploads (Issue #459).
+    ///
+    /// The simple `/content` PUT endpoint (`buildOneDriveUploadRequest`)
+    /// rejects anything over 4 MB
+    /// (`OneDriveUploader.simpleUploadMaxBytes`) — media output files
+    /// routinely exceed that, so this REQUIRED companion request starts
+    /// a resumable upload session at
+    /// `/me/drive/root:/<path>:/createUploadSession`. The JSON response
+    /// carries an `uploadUrl` that the caller (`CloudUploadExecutor
+    /// .uploadInSessionChunks`) then `PUT`s the file to in
+    /// `Content-Range`-addressed chunks.
+    ///
+    /// - Parameters:
+    ///   - filePath: The local file name to include in the remote path.
+    ///   - config: The OneDrive cloud storage configuration.
+    /// - Returns: A configured `URLRequest`, or `nil` if the URL is invalid.
+    public static func buildOneDriveCreateSessionRequest(
+        filePath: String,
+        config: CloudStorageConfig
+    ) -> URLRequest? {
+        let fileName = (filePath as NSString).lastPathComponent
+        let remoteDest = config.remotePath.hasSuffix("/")
+            ? config.remotePath + fileName
+            : config.remotePath + "/" + fileName
+
+        let encodedPath = remoteDest.addingPercentEncoding(
+            withAllowedCharacters: .urlPathAllowed
+        ) ?? remoteDest
+
+        let urlString = "https://graph.microsoft.com/v1.0/me/drive/root:\(encodedPath):/createUploadSession"
+        guard let url = URL(string: urlString) else {
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(config.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "item": [
+                "@microsoft.graph.conflictBehavior": "rename",
+            ],
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        return request
+    }
+
     // MARK: - Google Drive
 
     /// Build a Google Drive API v3 upload request.
@@ -255,5 +319,104 @@ public struct CloudStorageUploader: Sendable {
         // Force-unwrap is safe because the URL strings above are well-formed.
         // swiftlint:disable:next force_unwrapping
         return URL(string: urlString)!
+    }
+}
+
+// MARK: - CloudStorageProfileStore
+
+/// Read-only access to the cloud storage configurations saved by
+/// `CloudStorageView` (Issue #347 / #459), for consumers outside the
+/// app's SwiftUI layer — e.g. `PostEncodeActionChain.uploadViaCloud`
+/// (Issue #450), which runs inside `ConverterEngine` and has no view to
+/// bind form state to.
+///
+/// Mirrors `SFTPProfileStore`, which does the equivalent job for SFTP
+/// profiles: this does not duplicate storage. It reads the exact same
+/// `UserDefaults` blob `CloudStorageView` writes (provider / remotePath
+/// / label metadata, with the access/refresh token fields always
+/// redacted to empty/`nil`) and restores the real tokens from the
+/// Keychain via `APIKeyManager` — the same #380-audited secrets split
+/// every other provider in this codebase already uses.
+///
+/// Before Issue #459, `CloudStorageView` held `savedConfigs` purely in
+/// `@State` — it was never written to `UserDefaults` at all, so there
+/// was nothing for a non-UI consumer like `PostEncodeActionChain` to
+/// read. This store (and the matching persistence added to
+/// `CloudStorageView`) is what makes a saved cloud destination durable
+/// across app launches and referenceable by id from a post-encode
+/// action.
+public enum CloudStorageProfileStore {
+
+    /// `UserDefaults` key under which the redacted profile array lives.
+    /// Shared with `CloudStorageView` so the storage key cannot drift
+    /// between the write side (settings UI) and this read side.
+    public static let userDefaultsKey = "cloudStorageProfiles"
+
+    /// Loads every saved cloud storage configuration, restoring each
+    /// one's access/refresh token from the Keychain.
+    ///
+    /// - Parameter apiKeyManager: The manager to hydrate secrets from.
+    ///   Defaults to a fresh `APIKeyManager()` against the standard
+    ///   on-disk location (the same default `CloudStorageView` uses),
+    ///   so callers that don't already own an instance don't need to
+    ///   construct one.
+    /// - Returns: The saved configurations, or an empty array if none
+    ///   are saved or the stored JSON cannot be decoded.
+    public static func loadProfiles(
+        apiKeyManager: APIKeyManager = APIKeyManager()
+    ) -> [CloudStorageConfig] {
+        guard let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+              let profiles = try? JSONDecoder().decode([CloudStorageConfig].self, from: data) else {
+            return []
+        }
+
+        return profiles.map { profile in
+            guard profile.accessToken.isEmpty else { return profile }
+
+            let candidates = apiKeyManager.keys(for: apiKeyProvider(for: profile.provider))
+            guard let stored = candidates.first(where: { ($0.label ?? "") == profile.label }) ?? candidates.first,
+                  let token = stored.accessToken, !token.isEmpty else {
+                // No matching Keychain entry (deleted out of band, or
+                // never saved) — return the profile as-is. Callers
+                // should treat an empty accessToken as "credential
+                // unavailable" rather than assume it will authenticate,
+                // exactly as `SFTPProfileStore.loadProfiles()` treats an
+                // unrecoverable password.
+                return profile
+            }
+
+            var copy = profile
+            copy.accessToken = token
+            copy.refreshToken = stored.refreshToken
+            return copy
+        }
+    }
+
+    /// Looks up a single saved configuration by its stable `id`.
+    ///
+    /// - Parameters:
+    ///   - id: The configuration's `CloudStorageConfig.id`.
+    ///   - apiKeyManager: The manager to hydrate secrets from.
+    /// - Returns: The matching configuration (with its token restored
+    ///   from the Keychain when available), or `nil` if no
+    ///   configuration with that id is currently saved.
+    public static func profile(
+        withID id: UUID,
+        apiKeyManager: APIKeyManager = APIKeyManager()
+    ) -> CloudStorageConfig? {
+        loadProfiles(apiKeyManager: apiKeyManager).first { $0.id == id }
+    }
+
+    /// Maps the request-builder-side provider enum (`CloudStorageProvider`,
+    /// Issue #347) to the Keychain-side one (`APIKeyProvider`, Issue
+    /// #380). The two exist for historically separate features and use
+    /// slightly different case spellings (`onedrive` vs `oneDrive`) for
+    /// the same service.
+    public static func apiKeyProvider(for provider: CloudStorageProvider) -> APIKeyProvider {
+        switch provider {
+        case .dropbox: return .dropbox
+        case .onedrive: return .oneDrive
+        case .googleDrive: return .googleDrive
+        }
     }
 }

--- a/Sources/ConverterEngine/Cloud/CloudUploadExecutor.swift
+++ b/Sources/ConverterEngine/Cloud/CloudUploadExecutor.swift
@@ -1,0 +1,543 @@
+// ============================================================================
+// MeedyaConverter — CloudUploadExecutor (Issue #459)
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+
+import Foundation
+
+// MARK: - CloudUploadExecutor
+
+/// Executes cloud-storage upload `URLRequest`s built by
+/// `CloudStorageUploader` (Dropbox / Google Drive / OneDrive) and reports
+/// the real, verified outcome.
+///
+/// Before this type existed, every "upload" in this codebase stopped at
+/// building a `URLRequest` — nothing in `ConverterEngine` actually sent
+/// the bytes or inspected the server's response (see the doc comment
+/// this replaced on `PostEncodeActionType.uploadCloud`, and the
+/// `CloudStorageView.validateConfig()` method it also replaced — both
+/// only confirmed a request *could be built*, never that anything was
+/// *uploaded*). `CloudUploadExecutor` closes that gap using the same
+/// `URLSession` pattern already proven at
+/// `MediaServerNotifier.sendLibraryScan(config:)` and
+/// `WebhookSender.performRequest(bodyData:config:)`:
+///
+/// - The request is actually sent — `URLSession.upload(for:fromFile:)`
+///   for whole-file transfers, or sequential `PUT` requests with
+///   `Content-Range` headers for provider "upload session" large-file
+///   transfers (`uploadInSessionChunks`).
+/// - Only a genuine `2xx` HTTP status is treated as success.
+/// - Any other status — or a transport-level failure (DNS, TLS, timeout,
+///   connection reset, a filesystem error reading the local file) —
+///   surfaces as a thrown `UploadError` carrying the real status code
+///   and a snippet of the real response body. Nothing is ever
+///   fabricated.
+/// - Transient failures (429 Too Many Requests, 5xx) are retried with
+///   bounded exponential backoff — the same shape as
+///   `WebhookSender.send(payload:config:)`'s retry loop, generalised to
+///   branch on HTTP status as well as thrown errors. Non-transient
+///   failures (401/403/404/409/...) fail fast on the first response —
+///   retrying an invalid token or a permissions error can never
+///   succeed, so there is no reason to make the caller wait through the
+///   whole backoff schedule to find that out.
+///
+/// **Honesty contract**: this type NEVER returns a successful
+/// `UploadResult` unless the server actually accepted the request with
+/// a `2xx` status. Every failure path throws `UploadError`, carrying
+/// the real cause — see `CloudUploadExecutorTests` for the tests that
+/// pin this down against a `URLProtocol` mock (no real network I/O).
+///
+/// A plain struct rather than an actor or class: every stored property
+/// is an immutable `let`, set once at `init` and never mutated again, so
+/// there is no actor isolation needed to protect mutable state — the
+/// struct is trivially safe to share across concurrency domains and
+/// cheap to construct per call, exactly like `WebhookSender` and
+/// `MediaServerNotifier` elsewhere in this file's neighbourhood.
+/// `@unchecked Sendable` rather than plain `Sendable`: `URLSession` is
+/// itself thread-safe by design (it is documented as safe to share and
+/// use concurrently from multiple threads), but this file does not rely
+/// on the compiler having that exact `Sendable` audit recorded for the
+/// SDK's `URLSession` — the `let`-only, write-once-at-init shape here is
+/// what actually makes sharing this type safe, so `@unchecked` states
+/// that reasoning explicitly rather than depending on an SDK annotation
+/// this file can't independently verify.
+public struct CloudUploadExecutor: @unchecked Sendable {
+
+    // MARK: - RetryPolicy
+
+    /// Bounded exponential-backoff retry configuration.
+    public struct RetryPolicy: Sendable {
+        /// Total attempts, including the first. `1` disables retrying
+        /// (still exhausts one attempt, so a transient failure with
+        /// `maxAttempts == 1` still surfaces as `.allRetriesFailed`,
+        /// never fabricated success).
+        public var maxAttempts: Int
+
+        /// Delay before the first retry, in seconds. Doubles on each
+        /// subsequent retry (`initialDelay * 2^(attempt - 1)`), capped
+        /// at `maxDelay`.
+        public var initialDelay: TimeInterval
+
+        /// Upper bound on the backoff delay, in seconds.
+        public var maxDelay: TimeInterval
+
+        /// HTTP status codes considered transient and worth retrying.
+        /// Anything outside this set (e.g. 401, 403, 404, 409) fails
+        /// immediately on the first non-2xx response.
+        public var retryableStatusCodes: Set<Int>
+
+        public init(
+            maxAttempts: Int = 4,
+            initialDelay: TimeInterval = 1.0,
+            maxDelay: TimeInterval = 20.0,
+            retryableStatusCodes: Set<Int> = [429, 500, 502, 503, 504]
+        ) {
+            self.maxAttempts = max(1, maxAttempts)
+            self.initialDelay = initialDelay
+            self.maxDelay = maxDelay
+            self.retryableStatusCodes = retryableStatusCodes
+        }
+
+        /// The default policy: 4 attempts, 1s/2s/4s backoff capped at 20s.
+        public static let `default` = RetryPolicy()
+    }
+
+    // MARK: - UploadError
+
+    /// A real upload failure. Never fabricated — every case carries
+    /// information the server or `URLSession` actually reported.
+    public enum UploadError: LocalizedError, Sendable {
+        /// The response was not an `HTTPURLResponse` (should not happen
+        /// for `http(s)://` requests, but `URLSession` does not
+        /// statically guarantee it).
+        case invalidResponse
+
+        /// The server responded with a non-`2xx` status that is not in
+        /// `RetryPolicy.retryableStatusCodes` (or the last retry
+        /// attempt for a status that is). `bodySnippet` is the real
+        /// response body (truncated for readability), so the caller can
+        /// surface the provider's actual error message.
+        case httpError(statusCode: Int, bodySnippet: String)
+
+        /// A transport-level failure with no HTTP response at all — DNS,
+        /// TLS, timeout, connection reset, or a filesystem error reading
+        /// the local file (e.g. an unreadable upload-session response).
+        case transport(String)
+
+        /// Every retry attempt failed (each attempt either hit a
+        /// retryable HTTP status or a transport error). Carries the
+        /// most recent attempt's real error description.
+        case allRetriesFailed(lastError: String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidResponse:
+                return "The server returned a response that was not a valid HTTP response."
+            case .httpError(let statusCode, let bodySnippet):
+                return "Upload failed with HTTP \(statusCode): \(bodySnippet)"
+            case .transport(let message):
+                return "Upload failed: \(message)"
+            case .allRetriesFailed(let lastError):
+                return "Upload failed after all retry attempts. Last error: \(lastError)"
+            }
+        }
+    }
+
+    // MARK: - Properties
+
+    private let session: URLSession
+    private let retryPolicy: RetryPolicy
+
+    // MARK: - Initialiser
+
+    /// - Parameters:
+    ///   - session: The `URLSession` to execute requests on. Defaults to
+    ///     `.shared`; tests inject a session configured with a
+    ///     `URLProtocol` mock (see `CloudUploadExecutorTests`) so no
+    ///     real network I/O ever occurs.
+    ///   - retryPolicy: Retry/backoff configuration. Defaults to
+    ///     `.default` (4 attempts, 1s/2s/4s backoff).
+    public init(session: URLSession = .shared, retryPolicy: RetryPolicy = .default) {
+        self.session = session
+        self.retryPolicy = retryPolicy
+    }
+
+    // MARK: - Whole-file upload
+
+    /// Uploads `fileURL`'s bytes as the body of `request` and returns the
+    /// real outcome.
+    ///
+    /// Streams the file directly from disk via
+    /// `URLSession.upload(for:fromFile:)` — the file is never fully
+    /// loaded into memory, which matters for the multi-gigabyte media
+    /// files this app produces. `request` should already carry the
+    /// provider's method, URL, and headers (built by
+    /// `CloudStorageUploader` or an equivalent provider builder); this
+    /// method only adds transport, retry, and progress.
+    ///
+    /// - Parameters:
+    ///   - fileURL: The local file to upload.
+    ///   - request: The provider-specific upload request (method, URL,
+    ///     headers already set; the file supplies the body).
+    ///   - progress: Optional callback invoked with byte-level progress
+    ///     as the upload proceeds, via a `URLSessionTaskDelegate`
+    ///     (`UploadProgressObserver`, below). Called on whatever thread
+    ///     `URLSession`'s delegate queue uses — NOT guaranteed to be the
+    ///     main actor. Callers updating UI state must hop back
+    ///     themselves — see `CloudStorageView.performUpload()`'s
+    ///     `AsyncStream` bridge for the pattern this codebase uses.
+    ///   - parseSuccess: Optional callback that inspects the real 2xx
+    ///     response body/headers and extracts provider-specific
+    ///     identifiers (e.g. Dropbox's `path_display`/`id`, Google
+    ///     Drive's `id`/`webViewLink`). When omitted, `remoteURL`/
+    ///     `fileId` on the returned `UploadResult` are `nil` — never
+    ///     guessed.
+    /// - Returns: An `UploadResult` — only ever returned after a real
+    ///   `2xx` response.
+    /// - Throws: `UploadError` describing the real failure.
+    public func upload(
+        fileURL: URL,
+        request: URLRequest,
+        progress: (@Sendable (UploadProgress) -> Void)? = nil,
+        parseSuccess: (@Sendable (Data, HTTPURLResponse) -> (remoteURL: String?, fileId: String?))? = nil
+    ) async throws -> UploadResult {
+        let start = Date()
+        let totalBytes = Self.fileSize(at: fileURL) ?? 0
+
+        let (data, http) = try await executeWithRetry {
+            if let progress {
+                let observer = UploadProgressObserver { sent, expected in
+                    let total = expected > 0 ? expected : totalBytes
+                    progress(UploadProgress(bytesUploaded: sent, totalBytes: total))
+                }
+                return try await self.session.upload(for: request, fromFile: fileURL, delegate: observer)
+            } else {
+                return try await self.session.upload(for: request, fromFile: fileURL)
+            }
+        }
+
+        let ids = parseSuccess?(data, http) ?? (nil, nil)
+        return UploadResult(
+            remoteURL: ids.remoteURL,
+            fileId: ids.fileId,
+            fileSize: totalBytes,
+            uploadDuration: Date().timeIntervalSince(start),
+            verified: false
+        )
+    }
+
+    // MARK: - Chunked (upload-session) upload
+
+    /// Uploads a file too large for a single request via a provider
+    /// "upload session": one request to create the session (which
+    /// returns an `uploadUrl`), followed by sequential `PUT` requests
+    /// with `Content-Range` headers streaming the file in
+    /// `chunkSize`-byte windows.
+    ///
+    /// This is the Microsoft Graph (OneDrive/SharePoint) resumable
+    /// upload protocol — `createSessionRequest` should be built by
+    /// `CloudStorageUploader.buildOneDriveCreateSessionRequest(filePath:
+    /// config:)`. It is REQUIRED (not optional) for OneDrive because the
+    /// simple `/content` PUT endpoint rejects anything over 4 MB
+    /// (`OneDriveUploader.simpleUploadMaxBytes`), and the media files
+    /// this app produces routinely exceed that.
+    ///
+    /// - Parameters:
+    ///   - fileURL: The local file to upload.
+    ///   - createSessionRequest: The provider's "create upload session"
+    ///     request (method/URL/headers/body already set).
+    ///   - chunkSize: Bytes per `PUT`. Defaults to
+    ///     `OneDriveUploader.fragmentSize` (10 MB), which is already a
+    ///     multiple of the 320 KiB Microsoft Graph requires.
+    ///   - progress: Optional callback invoked after each chunk
+    ///     completes. Coarser than the byte-level callback on
+    ///     `upload(fileURL:request:progress:parseSuccess:)` since each
+    ///     chunk is sent as an in-memory `Data` blob rather than a
+    ///     streamed file and does not expose sub-chunk delegate
+    ///     callbacks; still real, server-acknowledged progress — never
+    ///     a fabricated estimate.
+    /// - Returns: An `UploadResult` built from the final chunk's real
+    ///   response (Microsoft Graph documents this as the created
+    ///   `DriveItem`, containing `id`/`webUrl`).
+    /// - Throws: `UploadError` describing the real failure — including
+    ///   `.transport` if the session-creation response has no
+    ///   `uploadUrl` (a malformed session request, or the provider
+    ///   changing its response shape) or if the local file cannot be
+    ///   read.
+    public func uploadInSessionChunks(
+        fileURL: URL,
+        createSessionRequest: URLRequest,
+        chunkSize: Int64 = OneDriveUploader.fragmentSize,
+        progress: (@Sendable (UploadProgress) -> Void)? = nil
+    ) async throws -> UploadResult {
+        let start = Date()
+        guard let totalBytes = Self.fileSize(at: fileURL), totalBytes > 0 else {
+            throw UploadError.transport("Could not determine the size of \(fileURL.lastPathComponent).")
+        }
+
+        let (sessionData, _) = try await executeWithRetry {
+            try await self.session.data(for: createSessionRequest)
+        }
+        guard let uploadURLString = Self.extractUploadURL(from: sessionData),
+              let uploadURL = URL(string: uploadURLString) else {
+            throw UploadError.transport(
+                "The upload-session response did not include an 'uploadUrl' field."
+            )
+        }
+
+        let handle: FileHandle
+        do {
+            handle = try FileHandle(forReadingFrom: fileURL)
+        } catch {
+            throw UploadError.transport("Could not open \(fileURL.lastPathComponent) for reading: \(error.localizedDescription)")
+        }
+        defer { try? handle.close() }
+
+        var offset: Int64 = 0
+        var finalChunkData = Data()
+
+        while offset < totalBytes {
+            let thisChunkSize = Int(min(chunkSize, totalBytes - offset))
+            let chunk: Data
+            do {
+                guard let read = try handle.read(upToCount: thisChunkSize), !read.isEmpty else {
+                    throw UploadError.transport(
+                        "Unexpected end of file while reading the upload chunk at offset \(offset)."
+                    )
+                }
+                chunk = read
+            } catch let err as UploadError {
+                throw err
+            } catch {
+                throw UploadError.transport("Could not read the upload chunk at offset \(offset): \(error.localizedDescription)")
+            }
+
+            let rangeEnd = offset + Int64(chunk.count) - 1
+            var chunkRequest = URLRequest(url: uploadURL)
+            chunkRequest.httpMethod = "PUT"
+            chunkRequest.setValue("\(chunk.count)", forHTTPHeaderField: "Content-Length")
+            chunkRequest.setValue(
+                "bytes \(offset)-\(rangeEnd)/\(totalBytes)",
+                forHTTPHeaderField: "Content-Range"
+            )
+
+            let (data, _) = try await executeWithRetry {
+                try await self.session.upload(for: chunkRequest, from: chunk)
+            }
+
+            offset += Int64(chunk.count)
+            finalChunkData = data
+            progress?(UploadProgress(bytesUploaded: offset, totalBytes: totalBytes))
+        }
+
+        let ids = Self.parseGraphIdentifiers(from: finalChunkData)
+        return UploadResult(
+            remoteURL: ids.remoteURL,
+            fileId: ids.fileId,
+            fileSize: totalBytes,
+            uploadDuration: Date().timeIntervalSince(start),
+            verified: false
+        )
+    }
+
+    // MARK: - Retry core
+
+    /// Runs `attempt` up to `retryPolicy.maxAttempts` times, retrying on
+    /// transient HTTP statuses (`retryPolicy.retryableStatusCodes`) or
+    /// thrown transport errors, with exponential backoff between
+    /// attempts.
+    ///
+    /// A non-retryable HTTP status (outside `retryableStatusCodes`)
+    /// throws `.httpError` immediately, without waiting through the
+    /// remaining backoff schedule — retrying a 401/403/404/409 can
+    /// never succeed. A retryable status or a thrown transport error
+    /// that survives every attempt instead falls through to
+    /// `.allRetriesFailed(lastError:)` once the loop is exhausted,
+    /// mirroring `WebhookSender.send(payload:config:)`'s retry shape.
+    private func executeWithRetry(
+        _ attempt: @Sendable () async throws -> (Data, URLResponse)
+    ) async throws -> (Data, HTTPURLResponse) {
+        var lastErrorMessage = "Unknown error"
+
+        for attemptNumber in 1...retryPolicy.maxAttempts {
+            do {
+                let (data, response) = try await attempt()
+                guard let http = response as? HTTPURLResponse else {
+                    throw UploadError.invalidResponse
+                }
+                if (200..<300).contains(http.statusCode) {
+                    return (data, http)
+                }
+
+                let httpErr = UploadError.httpError(
+                    statusCode: http.statusCode,
+                    bodySnippet: Self.snippet(from: data)
+                )
+                guard retryPolicy.retryableStatusCodes.contains(http.statusCode) else {
+                    throw httpErr
+                }
+                lastErrorMessage = httpErr.errorDescription ?? "HTTP \(http.statusCode)"
+            } catch let err as UploadError {
+                throw err
+            } catch {
+                lastErrorMessage = error.localizedDescription
+            }
+
+            if attemptNumber < retryPolicy.maxAttempts {
+                try await Task.sleep(for: .seconds(Self.backoffDelay(attempt: attemptNumber, policy: retryPolicy)))
+            }
+        }
+
+        throw UploadError.allRetriesFailed(lastError: lastErrorMessage)
+    }
+
+    // MARK: - Helpers
+
+    private static func backoffDelay(attempt: Int, policy: RetryPolicy) -> Double {
+        let raw = policy.initialDelay * pow(2.0, Double(attempt - 1))
+        return min(raw, policy.maxDelay)
+    }
+
+    private static func snippet(from data: Data, limit: Int = 500) -> String {
+        guard !data.isEmpty else { return "<empty body>" }
+        guard let text = String(data: data, encoding: .utf8) else {
+            return "<\(data.count) bytes, non-UTF8 body>"
+        }
+        if text.count > limit {
+            return String(text.prefix(limit)) + "…"
+        }
+        return text
+    }
+
+    private static func fileSize(at url: URL) -> Int64? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+            return nil
+        }
+        return attrs[.size] as? Int64
+    }
+
+    private static func extractUploadURL(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json["uploadUrl"] as? String
+    }
+
+    private static func parseGraphIdentifiers(from data: Data) -> (remoteURL: String?, fileId: String?) {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return (nil, nil)
+        }
+        return (json["webUrl"] as? String, json["id"] as? String)
+    }
+}
+
+// MARK: - CloudUploadExecutor + provider routing
+
+extension CloudUploadExecutor {
+
+    /// Uploads `fileURL` to the destination described by `config`,
+    /// automatically choosing the right provider request-builder and —
+    /// for OneDrive — the small-file `/content` PUT vs. the chunked
+    /// upload-session path based on the real on-disk file size.
+    ///
+    /// Shared by `CloudStorageView.performUpload()` (Issue #459) and
+    /// `PostEncodeActionChain.uploadViaCloud(action:outputURL:)` (Issue
+    /// #450) so the "which request builder, which OneDrive path" logic
+    /// lives in exactly one place rather than being duplicated between
+    /// the SwiftUI settings view and the post-encode action chain.
+    ///
+    /// - Parameters:
+    ///   - fileURL: The local file to upload.
+    ///   - config: The destination provider, credentials, and remote
+    ///     path (built by `CloudStorageView` or loaded from
+    ///     `CloudStorageProfileStore`).
+    ///   - progress: Optional progress callback — see
+    ///     `upload(fileURL:request:progress:parseSuccess:)` for its
+    ///     threading contract.
+    /// - Returns: The real `UploadResult`.
+    /// - Throws: `UploadError` if the request could not be built or the
+    ///   real transfer failed.
+    public func uploadToCloudStorage(
+        fileURL: URL,
+        config: CloudStorageConfig,
+        progress: (@Sendable (UploadProgress) -> Void)? = nil
+    ) async throws -> UploadResult {
+        let fileName = fileURL.lastPathComponent
+
+        switch config.provider {
+        case .dropbox:
+            guard let request = CloudStorageUploader.buildDropboxUploadRequest(
+                filePath: fileName,
+                config: config
+            ) else {
+                throw UploadError.transport("Could not build the Dropbox upload request.")
+            }
+            return try await upload(fileURL: fileURL, request: request, progress: progress)
+
+        case .googleDrive:
+            guard let request = CloudStorageUploader.buildGoogleDriveUploadRequest(
+                filePath: fileName,
+                config: config
+            ) else {
+                throw UploadError.transport("Could not build the Google Drive upload request.")
+            }
+            return try await upload(fileURL: fileURL, request: request, progress: progress)
+
+        case .onedrive:
+            let fileSize = Self.fileSize(at: fileURL)
+
+            if let fileSize, fileSize > OneDriveUploader.simpleUploadMaxBytes {
+                guard let sessionRequest = CloudStorageUploader.buildOneDriveCreateSessionRequest(
+                    filePath: fileName,
+                    config: config
+                ) else {
+                    throw UploadError.transport("Could not build the OneDrive upload-session request.")
+                }
+                return try await uploadInSessionChunks(
+                    fileURL: fileURL,
+                    createSessionRequest: sessionRequest,
+                    progress: progress
+                )
+            }
+
+            guard let request = CloudStorageUploader.buildOneDriveUploadRequest(
+                filePath: fileName,
+                config: config
+            ) else {
+                throw UploadError.transport("Could not build the OneDrive upload request.")
+            }
+            return try await upload(fileURL: fileURL, request: request, progress: progress)
+        }
+    }
+}
+
+// MARK: - UploadProgressObserver
+
+/// Bridges `URLSessionTaskDelegate`'s `didSendBodyData` callback (fired
+/// on whatever queue `URLSession` uses internally, not necessarily the
+/// caller's) into a plain `@Sendable` closure.
+///
+/// `@unchecked Sendable`: the only Swift-visible stored property is an
+/// immutable (`let`) `@Sendable` closure captured at `init`. `NSObject`'s
+/// own internal state is opaque to Swift's Sendable checker but is never
+/// touched by this subclass, so there is nothing here for a data race to
+/// reach.
+private final class UploadProgressObserver: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let onProgress: @Sendable (Int64, Int64) -> Void
+
+    init(onProgress: @escaping @Sendable (Int64, Int64) -> Void) {
+        self.onProgress = onProgress
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didSendBodyData bytesSent: Int64,
+        totalBytesSent: Int64,
+        totalBytesExpectedToSend: Int64
+    ) {
+        onProgress(totalBytesSent, totalBytesExpectedToSend)
+    }
+}

--- a/Sources/ConverterEngine/Cloud/CloudUploadExecutor.swift
+++ b/Sources/ConverterEngine/Cloud/CloudUploadExecutor.swift
@@ -218,7 +218,7 @@ public struct CloudUploadExecutor: @unchecked Sendable {
             }
         }
 
-        let ids = parseSuccess?(data, http) ?? (nil, nil)
+        let ids: (remoteURL: String?, fileId: String?) = parseSuccess?(data, http) ?? (nil, nil)
         return UploadResult(
             remoteURL: ids.remoteURL,
             fileId: ids.fileId,
@@ -315,13 +315,20 @@ public struct CloudUploadExecutor: @unchecked Sendable {
             }
 
             let rangeEnd = offset + Int64(chunk.count) - 1
-            var chunkRequest = URLRequest(url: uploadURL)
-            chunkRequest.httpMethod = "PUT"
-            chunkRequest.setValue("\(chunk.count)", forHTTPHeaderField: "Content-Length")
-            chunkRequest.setValue(
+            var mutableChunkRequest = URLRequest(url: uploadURL)
+            mutableChunkRequest.httpMethod = "PUT"
+            mutableChunkRequest.setValue("\(chunk.count)", forHTTPHeaderField: "Content-Length")
+            mutableChunkRequest.setValue(
                 "bytes \(offset)-\(rangeEnd)/\(totalBytes)",
                 forHTTPHeaderField: "Content-Range"
             )
+            // Captured below inside a `@Sendable` closure: Swift 6 strict
+            // concurrency rejects capturing a mutable `var` in
+            // concurrently-executing code (even though nothing mutates it
+            // after this point), so it is finalised into an immutable
+            // `let` first — the same "build mutable, hand off immutable"
+            // shape as `chunk` above.
+            let chunkRequest = mutableChunkRequest
 
             let (data, _) = try await executeWithRetry {
                 try await self.session.upload(for: chunkRequest, from: chunk)

--- a/Sources/ConverterEngine/Encoding/PostEncodeActions.swift
+++ b/Sources/ConverterEngine/Encoding/PostEncodeActions.swift
@@ -15,9 +15,11 @@ import AppKit
 /// The type of action to execute after an encoding job completes.
 ///
 /// Actions run in the order they appear in a `PostEncodeActionChain`.
-/// `.uploadCloud` remains reserved for future implementation and
-/// currently throws an "unsupported" error if executed — see its doc
-/// comment for why (Issue #450).
+/// All cases execute for real — `.uploadSFTP` (Issue #450) and
+/// `.uploadCloud` (Issue #459) both perform a genuine, authenticated
+/// transfer and only report success when the destination actually
+/// accepted the bytes; see their doc comments for the execution path
+/// each one uses.
 public enum PostEncodeActionType: String, Codable, Sendable, CaseIterable {
     /// Move the source file to the macOS Trash.
     case moveSourceToTrash
@@ -38,14 +40,15 @@ public enum PostEncodeActionType: String, Codable, Sendable, CaseIterable {
     /// (Issue #450). See `PostEncodeAction.config` for the expected key.
     case uploadSFTP
 
-    /// Upload the output file to cloud storage (future — not yet
-    /// implemented). `CloudStorageUploader` / `VideoUploader` /
-    /// `S3Uploader` only build `URLRequest`s / argument lists for a
-    /// hand-entered OAuth token — nothing in this codebase actually
-    /// executes an authenticated network upload of file bytes for any
-    /// cloud provider, so there is no real API yet for this action to
-    /// call. Wiring this honestly requires that execution path to exist
-    /// first (tracked separately from Issue #450).
+    /// Upload the output file to a saved cloud storage configuration
+    /// (Dropbox / Google Drive / OneDrive), using a profile saved in
+    /// `CloudStorageView` and looked up through
+    /// `CloudStorageProfileStore` (Issue #459 — mirrors the
+    /// `.uploadSFTP` wiring shipped for Issue #450). See
+    /// `PostEncodeAction.config` for the expected key. S3/YouTube/Vimeo
+    /// and full OAuth PKCE remain out of scope for this action; see
+    /// `CloudUploadExecutor`'s doc comment for what token-based
+    /// providers it actually executes.
     case uploadCloud
 
     /// Send a macOS notification with a custom message.
@@ -87,6 +90,12 @@ public struct PostEncodeAction: Identifiable, Codable, Sendable {
     ///   `SFTPProfileStore`). No credentials are ever stored here —
     ///   only a reference to a profile whose secret lives in the
     ///   Keychain via `SFTPCredentialStore`.
+    /// - `.uploadCloud`: `"cloudProfileID"` — the `UUID` string of a
+    ///   saved `CloudStorageConfig` (see `CloudStorageView` /
+    ///   `CloudStorageProfileStore`). As with `.uploadSFTP`, no
+    ///   credential is ever stored here — only a reference to a
+    ///   configuration whose OAuth token lives in the Keychain via
+    ///   `APIKeyManager`.
     public var config: [String: String]
 
     /// Whether this action is enabled. Disabled actions are skipped.
@@ -176,17 +185,7 @@ public struct PostEncodeActionChain: Codable, Sendable {
             case .shellScriptFailed(let code, let output):
                 return "Shell script exited with code \(code): \(output)"
             case .unsupportedAction(let type):
-                switch type {
-                case .uploadCloud:
-                    return "Action type 'uploadCloud' requires cloud-upload execution "
-                        + "support (OAuth token exchange + authenticated file transfer) "
-                        + "that does not exist yet in this codebase — only "
-                        + "request-builder helpers (CloudStorageUploader, VideoUploader, "
-                        + "S3Uploader) are implemented, not real execution. Not "
-                        + "implemented (Issue #450)."
-                default:
-                    return "Action type '\(type.rawValue)' is not yet supported."
-                }
+                return "Action type '\(type.rawValue)' is not yet supported."
             case .missingConfig(let key, let name):
                 return "Action '\(name)' is missing required config key '\(key)'."
             case .uploadFailed(let name, let message):
@@ -304,12 +303,7 @@ public struct PostEncodeActionChain: Codable, Sendable {
             try await uploadViaSFTP(action: action, outputURL: outputURL)
 
         case .uploadCloud:
-            // Honest "not implemented" — see the doc comment on
-            // `PostEncodeActionType.uploadCloud` and Issue #450: no
-            // component in this codebase actually executes an
-            // authenticated cloud upload, so there is nothing real to
-            // wire this to yet.
-            throw ActionError.unsupportedAction(.uploadCloud)
+            try await uploadViaCloud(action: action, outputURL: outputURL)
         }
     }
 
@@ -395,6 +389,61 @@ public struct PostEncodeActionChain: Codable, Sendable {
 
         guard outcome.succeeded else {
             throw ActionError.uploadFailed(actionName: action.name, message: outcome.message)
+        }
+    }
+
+    /// Upload the encoded output file to a saved cloud storage
+    /// configuration (Dropbox / Google Drive / OneDrive), executing the
+    /// transfer for real via `CloudUploadExecutor` (Issue #459).
+    ///
+    /// Reuses the same plumbing end to end that `CloudStorageView`
+    /// uses, mirroring `uploadViaSFTP` above (Issue #450):
+    /// - `action.config["cloudProfileID"]` resolves to a configuration
+    ///   through `CloudStorageProfileStore.profile(withID:)`, which
+    ///   reads the same `UserDefaults` blob `CloudStorageView` writes
+    ///   and restores the access/refresh token from the Keychain via
+    ///   `APIKeyManager` — no credential is ever stored inside
+    ///   `PostEncodeAction.config`.
+    /// - `CloudUploadExecutor.uploadToCloudStorage(fileURL:config:)`
+    ///   picks the matching `CloudStorageUploader` request builder
+    ///   (Dropbox / Google Drive / OneDrive, including OneDrive's
+    ///   chunked upload-session path for files over 4 MB) and performs
+    ///   the real, authenticated transfer.
+    ///
+    /// Unlike `uploadViaSFTP`'s `scp` invocation, the executor's work is
+    /// genuinely `async` (no blocking `Process.waitUntilExit()`), so no
+    /// `Task.detached` hop is needed here — `await`ing it directly
+    /// never blocks a thread.
+    ///
+    /// - Parameters:
+    ///   - action: The configured `.uploadCloud` action.
+    ///   - outputURL: The encoded output file to upload.
+    /// - Throws: `ActionError.missingConfig` if no valid profile
+    ///   reference is configured, or `ActionError.uploadFailed` with
+    ///   the real executor error (`CloudUploadExecutor.UploadError`'s
+    ///   description — real HTTP status + body, or a real transport
+    ///   failure) if the transfer fails.
+    private func uploadViaCloud(action: PostEncodeAction, outputURL: URL) async throws {
+        guard let profileIDString = action.config["cloudProfileID"],
+              let profileID = UUID(uuidString: profileIDString),
+              let profile = CloudStorageProfileStore.profile(withID: profileID) else {
+            throw ActionError.missingConfig(key: "cloudProfileID", actionName: action.name)
+        }
+
+        guard !profile.accessToken.isEmpty else {
+            throw ActionError.uploadFailed(
+                actionName: action.name,
+                message: "No access token is saved for \(profile.provider.rawValue). "
+                    + "Paste an OAuth token in Cloud Storage settings and save the "
+                    + "configuration first."
+            )
+        }
+
+        let executor = CloudUploadExecutor()
+        do {
+            _ = try await executor.uploadToCloudStorage(fileURL: outputURL, config: profile)
+        } catch {
+            throw ActionError.uploadFailed(actionName: action.name, message: error.localizedDescription)
         }
     }
 

--- a/Sources/MeedyaConverter/Views/CloudStorageView.swift
+++ b/Sources/MeedyaConverter/Views/CloudStorageView.swift
@@ -44,16 +44,34 @@ struct CloudStorageView: View {
     /// A user-facing label for this saved configuration.
     @State private var label = ""
 
-    /// The list of saved cloud storage configurations.
+    /// The list of saved cloud storage configurations. Hydrated from
+    /// `CloudStorageProfileStore` on appear and persisted through
+    /// `persistConfigs()` (Issue #459) — before #459 this array was
+    /// pure `@State` and never survived an app relaunch.
     @State private var savedConfigs: [CloudStorageConfig] = []
 
     /// The index of the currently selected saved configuration.
     @State private var selectedConfigIndex: Int?
 
+    /// The Keychain-backed store for provider OAuth tokens (Issue
+    /// #459). `@State` so this class instance — and the `keys` it
+    /// caches after `loadKeys()` — survives across this view's body
+    /// re-evaluations, matching the `@State private var manager = ...`
+    /// pattern already used by `ThemeSettingsView` / `PluginManagerView`
+    /// / `RecentFilesView` for other on-disk-backed managers.
+    @State private var apiKeyManager = APIKeyManager()
+
+    /// The local file path to test-upload via the real executor.
+    /// Defaults to the currently selected source file (if any) so the
+    /// common case — "upload the file I'm already working with" — needs
+    /// no extra picking.
+    @State private var uploadFilePath = ""
+
     /// Whether an upload is currently in progress.
     @State private var isUploading = false
 
-    /// Upload progress fraction from 0.0 to 1.0.
+    /// Upload progress fraction from 0.0 to 1.0, driven by real
+    /// `CloudUploadExecutor` progress callbacks (see `performUpload()`).
     @State private var uploadProgress: Double = 0.0
 
     /// Status message from the last operation.
@@ -82,6 +100,16 @@ struct CloudStorageView: View {
             .formStyle(.grouped)
         }
         .navigationTitle("Cloud Storage")
+        .onAppear {
+            loadSavedConfigsFromDisk()
+            hydrateTokenForSelectedProvider()
+            if uploadFilePath.isEmpty, let selected = viewModel.selectedFile {
+                uploadFilePath = selected.fileURL.path
+            }
+        }
+        .onChange(of: selectedProvider) { _, _ in
+            hydrateTokenForSelectedProvider()
+        }
     }
 
     // MARK: - Saved Configurations List
@@ -198,9 +226,24 @@ struct CloudStorageView: View {
     // MARK: - Upload
 
     /// Section with upload controls and progress display.
+    ///
+    /// Issue #459: this used to only validate that a `URLRequest` could
+    /// be built ("Test Configuration") — it never sent anything, so a
+    /// wrong path, an expired token, or a real server-side rejection
+    /// all reported the same fake success. The button now binds to
+    /// `performUpload()`, which executes a real, authenticated transfer
+    /// via `CloudUploadExecutor` and reports the real outcome.
     @ViewBuilder
     private var uploadSection: some View {
         Section("Upload") {
+            HStack {
+                TextField("File to Upload", text: $uploadFilePath, prompt: Text("/path/to/output.mp4"))
+                    .textFieldStyle(.roundedBorder)
+                Button("Browse…") {
+                    browseForFile()
+                }
+            }
+
             if isUploading {
                 ProgressView(value: uploadProgress) {
                     Text("Uploading...")
@@ -210,13 +253,11 @@ struct CloudStorageView: View {
             }
 
             Button {
-                // Upload is triggered from the main conversion flow;
-                // this button validates the configuration.
-                validateConfig()
+                performUpload()
             } label: {
-                Label("Test Configuration", systemImage: "checkmark.circle")
+                Label("Upload File", systemImage: "arrow.up.circle")
             }
-            .disabled(accessToken.isEmpty || remotePath.isEmpty)
+            .disabled(accessToken.isEmpty || remotePath.isEmpty || uploadFilePath.isEmpty || isUploading)
         }
     }
 
@@ -270,45 +311,23 @@ struct CloudStorageView: View {
         isError = false
     }
 
-    /// Validate the current configuration by attempting to build a request.
-    private func validateConfig() {
-        let config = CloudStorageConfig(
-            provider: selectedProvider,
-            accessToken: accessToken,
-            refreshToken: refreshToken.isEmpty ? nil : refreshToken,
-            remotePath: remotePath,
-            label: label
-        )
-
-        let testRequest: URLRequest?
-        switch selectedProvider {
-        case .dropbox:
-            testRequest = CloudStorageUploader.buildDropboxUploadRequest(
-                filePath: "test.mp4",
-                config: config
-            )
-        case .onedrive:
-            testRequest = CloudStorageUploader.buildOneDriveUploadRequest(
-                filePath: "test.mp4",
-                config: config
-            )
-        case .googleDrive:
-            testRequest = CloudStorageUploader.buildGoogleDriveUploadRequest(
-                filePath: "test.mp4",
-                config: config
-            )
-        }
-
-        if testRequest != nil {
-            statusMessage = "Configuration is valid. Upload request can be built."
-            isError = false
-        } else {
-            statusMessage = "Invalid configuration. Could not build upload request."
-            isError = true
+    /// Opens a file panel to select the local file to test-upload.
+    /// Mirrors `SFTPSettingsView.browseForKeyFile()`.
+    private func browseForFile() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let url = panel.url {
+            uploadFilePath = url.path
         }
     }
 
-    /// Save the current form state as a new configuration.
+    /// Save the current form state as a new configuration and persist
+    /// it (Issue #459): the token goes to the Keychain via
+    /// `apiKeyManager`, and the redacted metadata goes to
+    /// `UserDefaults` so `PostEncodeActionChain.uploadViaCloud` can
+    /// resolve this configuration by id later. See `persistConfigs()`.
     private func saveCurrentConfig() {
         let config = CloudStorageConfig(
             provider: selectedProvider,
@@ -319,6 +338,7 @@ struct CloudStorageView: View {
         )
         savedConfigs.append(config)
         selectedConfigIndex = savedConfigs.count - 1
+        persistConfigs()
         statusMessage = "Configuration saved."
         isError = false
     }
@@ -332,12 +352,214 @@ struct CloudStorageView: View {
         label = config.label
     }
 
-    /// Delete the currently selected saved configuration.
+    /// Delete the currently selected saved configuration, including its
+    /// Keychain-stored token. Mirrors
+    /// `SFTPSettingsView.deleteProfile(at:)`'s cleanup — without this, a
+    /// deleted configuration's token would linger in the Keychain
+    /// indefinitely (orphaned but still resident).
     private func deleteSelectedConfig() {
         guard let idx = selectedConfigIndex, idx < savedConfigs.count else { return }
+        removeStoredToken(for: savedConfigs[idx])
         savedConfigs.remove(at: idx)
         selectedConfigIndex = nil
+        persistConfigs()
         statusMessage = "Configuration deleted."
         isError = false
+    }
+
+    // MARK: - Persistence (Issue #459)
+
+    /// `UserDefaults` key under which the redacted configuration array
+    /// lives. Sourced from `CloudStorageProfileStore.userDefaultsKey` so
+    /// this view and the read-only `CloudStorageProfileStore` used by
+    /// `PostEncodeActionChain` can never drift onto different keys.
+    private static let userDefaultsKey = CloudStorageProfileStore.userDefaultsKey
+
+    /// Loads saved configurations from `UserDefaults`, restoring each
+    /// entry's access/refresh token from the Keychain via
+    /// `apiKeyManager`. Delegates to `CloudStorageProfileStore` so the
+    /// read path is shared with `PostEncodeActionChain` rather than
+    /// reimplemented here.
+    private func loadSavedConfigsFromDisk() {
+        savedConfigs = CloudStorageProfileStore.loadProfiles(apiKeyManager: apiKeyManager)
+    }
+
+    /// Writes the current `savedConfigs` to `UserDefaults` with secrets
+    /// redacted, after pushing each entry's real access/refresh token to
+    /// the Keychain via `apiKeyManager`. This is the single chokepoint
+    /// where a token crosses from `@State` into durable storage — the
+    /// same "redact at the point of persistence" pattern
+    /// `SFTPSettingsView.persistProfiles()` uses for SFTP passwords —
+    /// so there is one place to audit for the #380 invariant ("no
+    /// secret in the on-disk JSON").
+    private func persistConfigs() {
+        var redacted: [CloudStorageConfig] = []
+
+        for config in savedConfigs {
+            if !config.accessToken.isEmpty {
+                // `clientId` is a single form field shared by every saved
+                // configuration in this view, so it must only overwrite
+                // the Keychain entry for the configuration currently
+                // being edited (matched by provider + label) — otherwise
+                // saving one configuration would stamp its Client ID
+                // onto every OTHER saved configuration's stored entry
+                // too. For any other configuration, preserve whatever
+                // apiKey value it already had in the Keychain.
+                let apiKeyToStore: String
+                if config.provider == selectedProvider && config.label == label {
+                    apiKeyToStore = clientId
+                } else {
+                    apiKeyToStore = apiKeyManager
+                        .keys(for: apiKeyProvider(for: config.provider))
+                        .first(where: { ($0.label ?? "") == config.label })?
+                        .apiKey ?? ""
+                }
+
+                apiKeyManager.storeKey(
+                    StoredAPIKey(
+                        provider: apiKeyProvider(for: config.provider),
+                        apiKey: apiKeyToStore,
+                        accessToken: config.accessToken,
+                        refreshToken: config.refreshToken,
+                        label: config.label
+                    )
+                )
+            }
+            var copy = config
+            copy.accessToken = ""
+            copy.refreshToken = nil
+            redacted.append(copy)
+        }
+
+        if let data = try? JSONEncoder().encode(redacted) {
+            UserDefaults.standard.set(data, forKey: Self.userDefaultsKey)
+        }
+    }
+
+    /// Removes a configuration's Keychain-stored token.
+    private func removeStoredToken(for config: CloudStorageConfig) {
+        apiKeyManager.removeKey(provider: apiKeyProvider(for: config.provider), label: config.label)
+    }
+
+    /// Maps the request-builder-side provider enum to the Keychain-side
+    /// one. Delegates to `CloudStorageProfileStore.apiKeyProvider(for:)`
+    /// so the mapping lives in exactly one place.
+    private func apiKeyProvider(for provider: CloudStorageProvider) -> APIKeyProvider {
+        CloudStorageProfileStore.apiKeyProvider(for: provider)
+    }
+
+    /// Loads a previously-saved token for `selectedProvider` (if any)
+    /// into the client ID / access / refresh token fields, so switching
+    /// the provider picker or reopening this view doesn't leave the
+    /// user re-pasting a token they already saved.
+    private func hydrateTokenForSelectedProvider() {
+        let matches = apiKeyManager.keys(for: apiKeyProvider(for: selectedProvider))
+        guard let stored = matches.first(where: { ($0.label ?? "") == label }) ?? matches.first else {
+            return
+        }
+        if let token = stored.accessToken, !token.isEmpty {
+            accessToken = token
+        }
+        if let refresh = stored.refreshToken, !refresh.isEmpty {
+            refreshToken = refresh
+        }
+        if !stored.apiKey.isEmpty {
+            clientId = stored.apiKey
+        }
+    }
+
+    // MARK: - Real Upload (Issue #459)
+
+    /// Performs a real, authenticated upload of `uploadFilePath` using
+    /// the currently-configured provider, via `CloudUploadExecutor`.
+    ///
+    /// Progress crosses from `CloudUploadExecutor`'s `@Sendable`
+    /// callback (invoked on whatever thread `URLSession`'s delegate
+    /// queue uses, not necessarily the main actor) into this view's
+    /// `@State` via an `AsyncStream` — the documented-safe bridge for
+    /// exactly this "background callback into SwiftUI state" shape,
+    /// which avoids ever capturing `self` (a non-`Sendable` `View`)
+    /// inside a `@Sendable` closure. `AsyncStream.Continuation` is
+    /// itself `Sendable`, so it is the only thing the progress closure
+    /// captures.
+    ///
+    /// The upload itself runs in a plain `Task { }` — not
+    /// `Task.detached` — created directly from this (main-actor-
+    /// isolated, since `CloudStorageView` is a `View`) method, the same
+    /// pattern `SFTPSettingsView.testConnection()` uses for its
+    /// connection probe. Unlike that probe's blocking `Process`
+    /// invocation, `CloudUploadExecutor`'s work is genuinely `async`
+    /// (`URLSession`, no blocking syscalls), so no `Task.detached` hop
+    /// off the main actor is needed here.
+    private func performUpload() {
+        guard !isUploading else { return }
+        guard !accessToken.isEmpty else {
+            statusMessage = "Enter an access token first."
+            isError = true
+            return
+        }
+        guard !uploadFilePath.isEmpty else {
+            statusMessage = "Choose a file to upload first."
+            isError = true
+            return
+        }
+
+        let fileURL = URL(fileURLWithPath: uploadFilePath)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            statusMessage = "File not found: \(uploadFilePath)"
+            isError = true
+            return
+        }
+
+        let config = CloudStorageConfig(
+            provider: selectedProvider,
+            accessToken: accessToken,
+            refreshToken: refreshToken.isEmpty ? nil : refreshToken,
+            remotePath: remotePath,
+            label: label.isEmpty ? providerDisplayName(selectedProvider) : label
+        )
+
+        isUploading = true
+        uploadProgress = 0
+        statusMessage = nil
+        isError = false
+
+        let (stream, continuation) = AsyncStream<UploadProgress>.makeStream()
+
+        let progressTask = Task {
+            for await update in stream {
+                uploadProgress = update.fraction
+            }
+        }
+
+        Task {
+            defer { progressTask.cancel() }
+            let executor = CloudUploadExecutor()
+
+            do {
+                let result = try await executor.uploadToCloudStorage(
+                    fileURL: fileURL,
+                    config: config
+                ) { update in
+                    continuation.yield(update)
+                }
+                continuation.finish()
+
+                isUploading = false
+                uploadProgress = 1.0
+                let formatter = ByteCountFormatter()
+                formatter.countStyle = .file
+                let sizeText = formatter.string(fromByteCount: result.fileSize)
+                let destination = result.remoteURL ?? config.remotePath
+                statusMessage = "Uploaded \(sizeText) to \(destination) "
+                    + "(\(String(format: "%.1f", result.uploadDuration))s)."
+                isError = false
+            } catch {
+                continuation.finish()
+                isUploading = false
+                statusMessage = error.localizedDescription
+                isError = true
+            }
+        }
     }
 }

--- a/Sources/MeedyaConverter/Views/PostEncodeActionsView.swift
+++ b/Sources/MeedyaConverter/Views/PostEncodeActionsView.swift
@@ -332,11 +332,34 @@ struct PostEncodeActionRow: View {
             }
 
         case .uploadCloud:
-            Text("Cloud upload is not yet available: no component in this app performs an "
-                + "authenticated upload to Dropbox, OneDrive, Google Drive, S3, YouTube, or "
-                + "Vimeo — only the request-builder helpers exist. Use SFTP upload instead.")
-                .font(.caption)
-                .foregroundStyle(.orange)
+            // Issue #459: Dropbox / Google Drive / OneDrive execute a
+            // real, authenticated upload via `CloudUploadExecutor`.
+            // S3/YouTube/Vimeo remain out of scope — see
+            // `CloudUploadExecutor`'s doc comment.
+            let profiles = CloudStorageProfileStore.loadProfiles()
+            if profiles.isEmpty {
+                Text("No saved cloud storage configurations. Add one in Settings → Cloud Storage, then pick it here.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            } else {
+                Picker(
+                    "Cloud Storage Configuration",
+                    selection: Binding(
+                        get: { action.config["cloudProfileID"] ?? "" },
+                        set: { action.config["cloudProfileID"] = $0 }
+                    )
+                ) {
+                    Text("Select a configuration…").tag("")
+                    ForEach(profiles, id: \.id) { profile in
+                        Text("\(profile.label) (\(profile.provider.rawValue))").tag(profile.id.uuidString)
+                    }
+                }
+                .accessibilityLabel("Cloud storage configuration")
+
+                Text("Uploads the encoded output file to the selected Dropbox, Google Drive, or OneDrive destination.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
 
         // "Run on failure" toggle — common to all action types.
@@ -426,7 +449,7 @@ struct AddActionSheet: View {
         case .runShellScript: return "Run Shell Script"
         case .webhook: return "Send Webhook"
         case .uploadSFTP: return "Upload via SFTP"
-        case .uploadCloud: return "Upload to Cloud (Not Yet Available)"
+        case .uploadCloud: return "Upload to Cloud"
         case .sendNotification: return "Send Notification"
         }
     }

--- a/Tests/ConverterEngineTests/CloudUploadExecutorTests.swift
+++ b/Tests/ConverterEngineTests/CloudUploadExecutorTests.swift
@@ -362,8 +362,18 @@ final class CloudUploadExecutorTests: XCTestCase {
         XCTAssertEqual(request.url?.absoluteString, "https://content.dropboxapi.com/2/files/upload")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer dbx_tok")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/octet-stream")
-        let apiArg = try XCTUnwrap(request.value(forHTTPHeaderField: "Dropbox-API-Arg"))
-        XCTAssertTrue(apiArg.contains("/Videos/movie.mp4"))
+        let apiArgString = try XCTUnwrap(request.value(forHTTPHeaderField: "Dropbox-API-Arg"))
+        // Decode as JSON rather than substring-matching the raw header:
+        // Foundation's JSONSerialization escapes "/" as "\/" by default, so
+        // a literal `.contains("/Videos/movie.mp4")` check is broken by
+        // valid, semantically-identical output (JSON unescapes "\/" to "/"
+        // on any conformant parse). Checking the decoded "path" value tests
+        // what actually matters — the destination path Dropbox receives.
+        let apiArgData = try XCTUnwrap(apiArgString.data(using: .utf8))
+        let apiArg = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: apiArgData) as? [String: Any]
+        )
+        XCTAssertEqual(apiArg["path"] as? String, "/Videos/movie.mp4")
     }
 
     func test_googleDriveRequestBuilder_methodURLHeaders() throws {

--- a/Tests/ConverterEngineTests/CloudUploadExecutorTests.swift
+++ b/Tests/ConverterEngineTests/CloudUploadExecutorTests.swift
@@ -1,0 +1,535 @@
+// ============================================================================
+// MeedyaConverter — CloudUploadExecutorTests (Issue #459)
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// MARK: - File Overview
+// ---------------------------------------------------------------------------
+// Pure, CI-runnable tests for `CloudUploadExecutor` — no real network I/O.
+// A minimal `MockURLProtocol` (no `URLProtocol` mock precedent existed
+// anywhere in this repo — grepped for one per the #459 task brief before
+// writing this) intercepts every request `URLSession` makes and hands back
+// scripted responses, so the executor's retry/backoff, status-code
+// validation, and error-surfacing logic can be exercised deterministically
+// and fast (retry delays are configured in hundredths of a second for these
+// tests — see `RetryPolicy(initialDelay:maxDelay:)` below).
+//
+// Only public API is exercised (`import ConverterEngine`, no `@testable`),
+// matching the policy documented at the top of `ConverterEngineTests.swift`.
+//
+// Decode-only / no-media: every "upload" here is a small temp file written
+// with `Data(repeating:count:)` or a short UTF-8 string — never a real
+// media file or codec.
+// ---------------------------------------------------------------------------
+
+import XCTest
+import ConverterEngine
+
+// MARK: - MockURLProtocol
+
+/// A minimal `URLProtocol` mock. Tests `enqueue(_:)` one responder per
+/// expected request (consumed FIFO), then register `MockURLProtocol` on a
+/// session's `URLSessionConfiguration.protocolClasses` so every request
+/// made through that session is intercepted instead of hitting the network.
+///
+/// `nonisolated(unsafe)` on the static queue/log: `lock` is the actual
+/// synchronization — every access happens under it — so these globals are
+/// safe despite opting out of the compiler's automatic static-state check,
+/// the same reasoning `SFTPUploadIOState` / `ProbeIOState` document for
+/// their `@unchecked Sendable` instance state elsewhere in this codebase.
+final class MockURLProtocol: URLProtocol, @unchecked Sendable {
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var responseQueue: [(URLRequest) throws -> (HTTPURLResponse, Data)] = []
+    nonisolated(unsafe) private static var requestLogStorage: [URLRequest] = []
+
+    /// Every request actually routed through this protocol, in order.
+    static var requestLog: [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestLogStorage
+    }
+
+    /// Registers one responder for the next intercepted request. Consumed
+    /// in FIFO order, so a test scripting "429 then 200" enqueues both
+    /// responders up front and the executor's two real attempts consume
+    /// them in sequence.
+    static func enqueue(_ responder: @escaping (URLRequest) throws -> (HTTPURLResponse, Data)) {
+        lock.lock()
+        responseQueue.append(responder)
+        lock.unlock()
+    }
+
+    /// Clears both the responder queue and the request log. Called from
+    /// `setUp`/`tearDown` so tests never see another test's leftover state.
+    static func reset() {
+        lock.lock()
+        responseQueue.removeAll()
+        requestLogStorage.removeAll()
+        lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.lock.lock()
+        Self.requestLogStorage.append(request)
+        let responder = Self.responseQueue.isEmpty ? nil : Self.responseQueue.removeFirst()
+        Self.lock.unlock()
+
+        guard let responder else {
+            // A test under-enqueued responders relative to the real
+            // number of attempts the executor made — fail loudly rather
+            // than hang, so a retry-count bug in either the test or the
+            // executor surfaces immediately.
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (response, data) = try responder(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+        // No cleanup needed — `startLoading()` completes synchronously.
+    }
+}
+
+// MARK: - CloudUploadExecutorTests
+
+final class CloudUploadExecutorTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private var session: URLSession!
+    private var tempFileURL: URL!
+    private let payload = "test upload payload"
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        MockURLProtocol.reset()
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: configuration)
+
+        tempFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cloud-upload-executor-tests-\(UUID().uuidString).bin")
+        try Data(payload.utf8).write(to: tempFileURL)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempFileURL)
+        MockURLProtocol.reset()
+        session = nil
+        super.tearDown()
+    }
+
+    private func makeResponse(
+        for request: URLRequest,
+        statusCode: Int,
+        headers: [String: String] = [:]
+    ) throws -> HTTPURLResponse {
+        try XCTUnwrap(
+            HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: headers
+            )
+        )
+    }
+
+    private func makeUploadRequest(url: String = "https://example.com/upload", method: String = "POST") -> URLRequest {
+        var request = URLRequest(url: URL(string: url)!)
+        request.httpMethod = method
+        return request
+    }
+
+    // MARK: - (a) Success only on 2xx
+
+    func test_upload_succeedsOn200_returnsRealUploadResult() async throws {
+        MockURLProtocol.enqueue { [self] request in
+            let response = try makeResponse(for: request, statusCode: 200)
+            return (response, Data("{\"id\":\"abc\"}".utf8))
+        }
+
+        let executor = CloudUploadExecutor(session: session, retryPolicy: .init(maxAttempts: 1))
+        let result = try await executor.upload(fileURL: tempFileURL, request: makeUploadRequest())
+
+        XCTAssertEqual(result.fileSize, Int64(payload.utf8.count))
+        XCTAssertGreaterThanOrEqual(result.uploadDuration, 0)
+        XCTAssertEqual(MockURLProtocol.requestLog.count, 1)
+    }
+
+    func test_upload_succeedsOn201_returnsRealUploadResult() async throws {
+        MockURLProtocol.enqueue { [self] request in
+            let response = try makeResponse(for: request, statusCode: 201)
+            return (response, Data("{\"id\":\"created\"}".utf8))
+        }
+
+        let executor = CloudUploadExecutor(session: session, retryPolicy: .init(maxAttempts: 1))
+        let result = try await executor.upload(fileURL: tempFileURL, request: makeUploadRequest())
+
+        XCTAssertEqual(result.fileSize, Int64(payload.utf8.count))
+    }
+
+    func test_upload_parseSuccess_extractsRealIdentifiersFromResponseBody() async throws {
+        MockURLProtocol.enqueue { [self] request in
+            let response = try makeResponse(for: request, statusCode: 200)
+            return (response, Data("{\"path_display\":\"/Videos/movie.mp4\",\"id\":\"dbx_id_1\"}".utf8))
+        }
+
+        let executor = CloudUploadExecutor(session: session, retryPolicy: .init(maxAttempts: 1))
+        let result = try await executor.upload(
+            fileURL: tempFileURL,
+            request: makeUploadRequest(),
+            parseSuccess: { data, _ in
+                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                return (json?["path_display"] as? String, json?["id"] as? String)
+            }
+        )
+
+        XCTAssertEqual(result.remoteURL, "/Videos/movie.mp4")
+        XCTAssertEqual(result.fileId, "dbx_id_1")
+    }
+
+    // MARK: - (b) Real failure with status + body on 4xx/5xx
+
+    func test_upload_throwsHTTPErrorWithRealStatusAndBody_on404() async throws {
+        MockURLProtocol.enqueue { [self] request in
+            let response = try makeResponse(for: request, statusCode: 404)
+            return (response, Data("{\"error\":\"path_not_found\"}".utf8))
+        }
+
+        let executor = CloudUploadExecutor(session: session, retryPolicy: .init(maxAttempts: 1))
+
+        do {
+            _ = try await executor.upload(fileURL: tempFileURL, request: makeUploadRequest())
+            XCTFail("Expected the upload to throw on a 404")
+        } catch let error as CloudUploadExecutor.UploadError {
+            guard case .httpError(let statusCode, let bodySnippet) = error else {
+                XCTFail("Expected .httpError, got \(error)")
+                return
+            }
+            XCTAssertEqual(statusCode, 404)
+            XCTAssertTrue(bodySnippet.contains("path_not_found"), "Body snippet must carry the real server error: \(bodySnippet)")
+        }
+    }
+
+    func test_upload_nonTransient403_failsImmediatelyWithoutRetrying() async throws {
+        // Only ONE responder is enqueued. If the executor retried a 403,
+        // the second attempt would find an empty queue and fail with
+        // .unknown instead of the real 403 — the assertion below on the
+        // request count is what actually proves no retry happened.
+        MockURLProtocol.enqueue { [self] request in
+            let response = try makeResponse(for: request, statusCode: 403)
+            return (response, Data("{\"error\":\"invalid_access_token\"}".utf8))
+        }
+
+        let executor = CloudUploadExecutor(
+            session: session,
+            retryPolicy: .init(maxAttempts: 4, initialDelay: 0.01, maxDelay: 0.02)
+        )
+
+        do {
+            _ = try await executor.upload(fileURL: tempFileURL, request: makeUploadRequest())
+            XCTFail("Expected the upload to throw on a 403")
+        } catch let error as CloudUploadExecutor.UploadError {
+            guard case .httpError(let statusCode, _) = error else {
+                XCTFail("Expected .httpError, got \(error)")
+                return
+            }
+            XCTAssertEqual(statusCode, 403)
+            XCTAssertEqual(MockURLProtocol.requestLog.count, 1, "A non-transient 403 must not be retried")
+        }
+    }
+
+    func test_upload_transportFailure_neverFabricatesSuccess() async throws {
+        MockURLProtocol.enqueue { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let executor = CloudUploadExecutor(session: session, retryPolicy: .init(maxAttempts: 1))
+
+        do {
+            _ = try await executor.upload(fileURL: tempFileURL, request: makeUploadRequest())
+            XCTFail("Expected the upload to throw on a transport failure")
+        } catch let error as CloudUploadExecutor.UploadError {
+            guard case .allRetriesFailed(let lastError) = error else {
+                XCTFail("Expected .allRetriesFailed, got \(error)")
+                return
+            }
+            XCTAssertFalse(lastError.isEmpty)
+        }
+    }
+
+    // MARK: - (c) Retries on 429/503 then succeeds
+
+    func test_upload_retriesOn429ThenSucceeds() async throws {
+        MockURLProtocol.enqueue { [self] request in
+            let response = try makeResponse(for: request, statusCode: 429)
+            return (response, Data())
+        }
+        MockURLProtocol.enqueue { [self] request in
+            let response = try makeResponse(for: request, statusCode: 200)
+            return (response, Data("{\"id\":\"ok\"}".utf8))
+        }
+
+        let executor = CloudUploadExecutor(
+            session: session,
+            retryPolicy: .init(maxAttempts: 3, initialDelay: 0.01, maxDelay: 0.02)
+        )
+        let result = try await executor.upload(fileURL: tempFileURL, request: makeUploadRequest())
+
+        XCTAssertEqual(MockURLProtocol.requestLog.count, 2, "Exactly one retry after the 429")
+        XCTAssertEqual(result.fileSize, Int64(payload.utf8.count))
+    }
+
+    func test_upload_retriesOn503ThenSucceeds() async throws {
+        MockURLProtocol.enqueue { [self] request in
+            let response = try makeResponse(for: request, statusCode: 503)
+            return (response, Data("{\"error\":\"unavailable\"}".utf8))
+        }
+        MockURLProtocol.enqueue { [self] request in
+            let response = try makeResponse(for: request, statusCode: 200)
+            return (response, Data("{\"id\":\"ok\"}".utf8))
+        }
+
+        let executor = CloudUploadExecutor(
+            session: session,
+            retryPolicy: .init(maxAttempts: 3, initialDelay: 0.01, maxDelay: 0.02)
+        )
+        let result = try await executor.upload(fileURL: tempFileURL, request: makeUploadRequest())
+
+        XCTAssertEqual(MockURLProtocol.requestLog.count, 2)
+        XCTAssertEqual(result.fileSize, Int64(payload.utf8.count))
+    }
+
+    func test_upload_allRetriesExhausted_throwsRealLastErrorNeverFabricatesSuccess() async throws {
+        // Three 503s in a row, matching maxAttempts: 3 — every attempt
+        // genuinely fails, so the executor must throw, never fabricate
+        // a success from an empty response queue.
+        for _ in 0..<3 {
+            MockURLProtocol.enqueue { [self] request in
+                let response = try makeResponse(for: request, statusCode: 503)
+                return (response, Data("{\"error\":\"unavailable\"}".utf8))
+            }
+        }
+
+        let executor = CloudUploadExecutor(
+            session: session,
+            retryPolicy: .init(maxAttempts: 3, initialDelay: 0.01, maxDelay: 0.02)
+        )
+
+        do {
+            _ = try await executor.upload(fileURL: tempFileURL, request: makeUploadRequest())
+            XCTFail("Expected the upload to throw once retries are exhausted")
+        } catch let error as CloudUploadExecutor.UploadError {
+            guard case .allRetriesFailed(let lastError) = error else {
+                XCTFail("Expected .allRetriesFailed, got \(error)")
+                return
+            }
+            XCTAssertTrue(lastError.contains("503"), "The real last HTTP status must be in the message: \(lastError)")
+            XCTAssertEqual(MockURLProtocol.requestLog.count, 3, "All 3 attempts must have been made")
+        }
+    }
+
+    // MARK: - (d) Provider request-builder correctness
+
+    func test_dropboxRequestBuilder_methodURLHeaders() throws {
+        let config = CloudStorageConfig(
+            provider: .dropbox,
+            accessToken: "dbx_tok",
+            remotePath: "/Videos",
+            label: "Work Dropbox"
+        )
+        let request = try XCTUnwrap(
+            CloudStorageUploader.buildDropboxUploadRequest(filePath: "movie.mp4", config: config)
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://content.dropboxapi.com/2/files/upload")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer dbx_tok")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/octet-stream")
+        let apiArg = try XCTUnwrap(request.value(forHTTPHeaderField: "Dropbox-API-Arg"))
+        XCTAssertTrue(apiArg.contains("/Videos/movie.mp4"))
+    }
+
+    func test_googleDriveRequestBuilder_methodURLHeaders() throws {
+        let config = CloudStorageConfig(
+            provider: .googleDrive,
+            accessToken: "ya29.tok",
+            remotePath: "/",
+            label: "Personal Drive"
+        )
+        let request = try XCTUnwrap(
+            CloudStorageUploader.buildGoogleDriveUploadRequest(filePath: "movie.mp4", config: config)
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        let urlString = try XCTUnwrap(request.url?.absoluteString)
+        XCTAssertTrue(urlString.contains("googleapis.com/upload/drive/v3/files"))
+        XCTAssertTrue(urlString.contains("uploadType=media"))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer ya29.tok")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/octet-stream")
+    }
+
+    func test_oneDriveSimpleUploadRequestBuilder_methodURLHeaders() throws {
+        let config = CloudStorageConfig(
+            provider: .onedrive,
+            accessToken: "msft_tok",
+            remotePath: "/Videos",
+            label: "OneDrive"
+        )
+        let request = try XCTUnwrap(
+            CloudStorageUploader.buildOneDriveUploadRequest(filePath: "movie.mp4", config: config)
+        )
+
+        XCTAssertEqual(request.httpMethod, "PUT")
+        let urlString = try XCTUnwrap(request.url?.absoluteString)
+        XCTAssertTrue(urlString.contains("graph.microsoft.com/v1.0"))
+        XCTAssertTrue(urlString.contains(":/content"))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer msft_tok")
+    }
+
+    func test_oneDriveCreateSessionRequestBuilder_methodURLBody() throws {
+        let config = CloudStorageConfig(
+            provider: .onedrive,
+            accessToken: "msft_tok",
+            remotePath: "/Videos",
+            label: "OneDrive"
+        )
+        let request = try XCTUnwrap(
+            CloudStorageUploader.buildOneDriveCreateSessionRequest(filePath: "big-movie.mkv", config: config)
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        let urlString = try XCTUnwrap(request.url?.absoluteString)
+        XCTAssertTrue(urlString.contains("/createUploadSession"))
+        XCTAssertTrue(urlString.contains("Videos"))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer msft_tok")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let bodyData = try XCTUnwrap(request.httpBody)
+        let bodyString = try XCTUnwrap(String(data: bodyData, encoding: .utf8))
+        XCTAssertTrue(bodyString.contains("conflictBehavior"))
+    }
+
+    // MARK: - uploadToCloudStorage: OneDrive size-based routing
+
+    func test_uploadToCloudStorage_oneDrive_smallFile_usesSimpleContentUpload() async throws {
+        MockURLProtocol.enqueue { [self] request in
+            XCTAssertTrue(request.url?.absoluteString.contains(":/content") == true)
+            XCTAssertEqual(request.httpMethod, "PUT")
+            let response = try makeResponse(for: request, statusCode: 200)
+            return (response, Data("{\"id\":\"small-item\"}".utf8))
+        }
+
+        let executor = CloudUploadExecutor(session: session, retryPolicy: .init(maxAttempts: 1))
+        let config = CloudStorageConfig(
+            provider: .onedrive,
+            accessToken: "tok",
+            remotePath: "/Videos",
+            label: "OneDrive"
+        )
+
+        let result = try await executor.uploadToCloudStorage(fileURL: tempFileURL, config: config)
+
+        XCTAssertEqual(MockURLProtocol.requestLog.count, 1, "A small file must use the single-PUT path, not a session")
+        XCTAssertEqual(result.fileSize, Int64(payload.utf8.count))
+    }
+
+    func test_uploadToCloudStorage_oneDrive_largeFile_usesUploadSession() async throws {
+        // A file just over OneDriveUploader.simpleUploadMaxBytes (4 MB)
+        // must route through the create-session + chunked-PUT path —
+        // required for OneDrive per the #459 task brief, since the
+        // simple /content endpoint rejects anything this large.
+        let bigFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cloud-upload-executor-tests-large-\(UUID().uuidString).bin")
+        defer { try? FileManager.default.removeItem(at: bigFileURL) }
+        let bigSize = Int(OneDriveUploader.simpleUploadMaxBytes) + 1024
+        try Data(repeating: 0x42, count: bigSize).write(to: bigFileURL)
+
+        // 1: create-session response carries the real uploadUrl.
+        MockURLProtocol.enqueue { [self] request in
+            XCTAssertTrue(request.url?.absoluteString.contains("/createUploadSession") == true)
+            XCTAssertEqual(request.httpMethod, "POST")
+            let body = "{\"uploadUrl\":\"https://graph.microsoft.com/fake-session/1\"}"
+            let response = try makeResponse(for: request, statusCode: 200)
+            return (response, Data(body.utf8))
+        }
+        // 2: the file fits in a single chunk (default fragmentSize is
+        // 10 MB, well over ~4 MB), so exactly one chunk PUT follows.
+        MockURLProtocol.enqueue { [self] request in
+            XCTAssertEqual(request.httpMethod, "PUT")
+            XCTAssertEqual(request.url?.absoluteString, "https://graph.microsoft.com/fake-session/1")
+            let contentRange = request.value(forHTTPHeaderField: "Content-Range")
+            XCTAssertEqual(contentRange, "bytes 0-\(bigSize - 1)/\(bigSize)")
+            let body = "{\"id\":\"large-item\",\"webUrl\":\"https://onedrive.example/large-item\"}"
+            let response = try makeResponse(for: request, statusCode: 201)
+            return (response, Data(body.utf8))
+        }
+
+        let executor = CloudUploadExecutor(session: session, retryPolicy: .init(maxAttempts: 1))
+        let config = CloudStorageConfig(
+            provider: .onedrive,
+            accessToken: "tok",
+            remotePath: "/Videos",
+            label: "OneDrive"
+        )
+
+        let result = try await executor.uploadToCloudStorage(fileURL: bigFileURL, config: config)
+
+        XCTAssertEqual(MockURLProtocol.requestLog.count, 2, "create-session + exactly one chunk PUT")
+        XCTAssertEqual(result.remoteURL, "https://onedrive.example/large-item")
+        XCTAssertEqual(result.fileId, "large-item")
+        XCTAssertEqual(result.fileSize, Int64(bigSize))
+    }
+
+    func test_uploadToCloudStorage_oneDrive_sessionMissingUploadURL_throwsHonestError() async throws {
+        MockURLProtocol.enqueue { [self] request in
+            // Malformed session response — no "uploadUrl" field.
+            let response = try makeResponse(for: request, statusCode: 200)
+            return (response, Data("{}".utf8))
+        }
+
+        let bigFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cloud-upload-executor-tests-large-\(UUID().uuidString).bin")
+        defer { try? FileManager.default.removeItem(at: bigFileURL) }
+        let bigSize = Int(OneDriveUploader.simpleUploadMaxBytes) + 1024
+        try Data(repeating: 0x00, count: bigSize).write(to: bigFileURL)
+
+        let executor = CloudUploadExecutor(session: session, retryPolicy: .init(maxAttempts: 1))
+        let config = CloudStorageConfig(
+            provider: .onedrive,
+            accessToken: "tok",
+            remotePath: "/Videos",
+            label: "OneDrive"
+        )
+
+        do {
+            _ = try await executor.uploadToCloudStorage(fileURL: bigFileURL, config: config)
+            XCTFail("Expected a thrown error for a session response missing uploadUrl")
+        } catch let error as CloudUploadExecutor.UploadError {
+            guard case .transport(let message) = error else {
+                XCTFail("Expected .transport, got \(error)")
+                return
+            }
+            XCTAssertTrue(message.contains("uploadUrl"))
+            // Only the create-session request should have gone out — no
+            // fabricated chunk PUT after a malformed session response.
+            XCTAssertEqual(MockURLProtocol.requestLog.count, 1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the cloud-upload **execution** layer (#459, Bundle 1 core) — previously every provider only *built* a `URLRequest` and never sent it. New `CloudUploadExecutor` does real `URLSession.upload(for:fromFile:)` with **2xx-only success**, retry+backoff on 429/5xx, byte-level progress, and OneDrive create-session chunked upload for large media. Token-based providers (Dropbox, Google Drive, OneDrive) are wired end-to-end with Keychain-persisted tokens; `PostEncodeActions.uploadCloud` now executes for real. **S3 SigV4 + YouTube/Vimeo follow in a second PR.**

## Changes Made

- [x] **`CloudUploadExecutor.swift`** (new) — real upload, 2xx-only, retry/backoff, progress via `URLSessionTaskDelegate`, OneDrive chunked-session path; `@unchecked Sendable` (write-once, no mutation)
- [x] **Dropbox / Google Drive / OneDrive** wired (`CloudStorageUploader`, `CloudStorageView`) — real "Upload File" button + progress + error; tokens persisted via `APIKeyManager` (Keychain) + new `CloudStorageProfileStore`; deleted the "Upload request can be built" fake path
- [x] **`PostEncodeActions.uploadCloud`** → executor (re #450), mirroring the shipped `.uploadSFTP` wiring; credentials never in `config` (only a profile UUID)
- [x] **21 unit tests** (`CloudUploadExecutorTests.swift` + new `MockURLProtocol`): 2xx-only success, real 4xx/5xx failure, no-retry on 403, retry-then-succeed on 429/503, per-provider builders, OneDrive size routing

## Testing Done

CI is the gate (macOS-only, not locally buildable) — including **security checks** (CodeQL, Dependency Review, pin-hygiene). Watch these flagged spots: `URLProtocol` interception of `upload(fromFile:)`; `MockURLProtocol` static state under Swift 6 strict concurrency; the `Task`-inherits-isolation capture in `CloudStorageView` (mirrors shipped `SFTPSettingsView.testConnection`).

- [ ] Build & Test (macOS) · CodeQL · Review Dependencies · pin hygiene · actionlint

## Related Issues

Addresses #459 (token providers + executor; S3/YouTube-Vimeo follow) and #450 (cloud half). Evidence for the closed-in-error cloud issues (#161–#175, #347, #294) will be posted once the full executor lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NF44GLcMisedfvxHzhscJQ)_