### PR TITLE
Implement perceptual-hash duplicate matching (#449)

### DIFF
--- a/Sources/ConverterEngine/Utilities/DuplicateDetector.swift
+++ b/Sources/ConverterEngine/Utilities/DuplicateDetector.swift
@@ -25,7 +25,9 @@ public enum MatchType: String, Sendable, CaseIterable {
     /// Files whose durations differ by at most 1 second.
     case similarDuration
 
-    /// Perceptual fingerprint comparison (placeholder for future implementation).
+    /// Perceptual fingerprint comparison — DCT-based pHash over sampled
+    /// frames (see `PerceptualHasher`). Catches re-encodes, transcodes,
+    /// and trims that `.exactHash`/`.sameSize` miss (Issue #449).
     case perceptual
 }
 
@@ -89,8 +91,16 @@ public struct DuplicateDetector: Sendable {
     /// - Parameters:
     ///   - urls: The file URLs to analyse.
     ///   - method: The matching algorithm to apply.
+    ///   - perceptualThreshold: Maximum mean Hamming distance (out of 64)
+    ///     for two files to be grouped under `.perceptual` matching. Only
+    ///     consulted when `method == .perceptual`; defaults to
+    ///     `PerceptualHasher.defaultDistanceThreshold`.
     /// - Returns: An array of `DuplicateGroup` instances, each containing two or more files.
-    public static func findDuplicates(in urls: [URL], method: MatchType) async -> [DuplicateGroup] {
+    public static func findDuplicates(
+        in urls: [URL],
+        method: MatchType,
+        perceptualThreshold: Int = PerceptualHasher.defaultDistanceThreshold
+    ) async -> [DuplicateGroup] {
         switch method {
         case .exactHash:
             return findByExactHash(urls)
@@ -99,8 +109,7 @@ public struct DuplicateDetector: Sendable {
         case .similarDuration:
             return await findBySimilarDuration(urls)
         case .perceptual:
-            // Perceptual hashing is a placeholder; returns empty for now.
-            return []
+            return await findByPerceptualHash(urls, threshold: perceptualThreshold)
         }
     }
 
@@ -184,6 +193,56 @@ public struct DuplicateDetector: Sendable {
         }
 
         return groups
+    }
+
+    /// Groups files by perceptual (pHash) similarity across sampled frames.
+    ///
+    /// Each candidate is sampled and hashed via `PerceptualHasher.hashFile`
+    /// (blocking `AVFoundation` decode is isolated off-main inside the
+    /// sampler itself — see `AVAssetFrameSampler`'s doc comment), then
+    /// files are transitively grouped by `PerceptualHasher.groupByDistance`
+    /// wherever their mean Hamming distance falls within `threshold`.
+    ///
+    /// Files that cannot be decoded (corrupt media, non-video content,
+    /// zero/invalid duration, no readable frames) are skipped with a
+    /// logged reason — never silently dropped without explanation, and
+    /// never fabricated into a group.
+    ///
+    /// - Parameters:
+    ///   - urls: Candidate file URLs.
+    ///   - sampler: The `FrameSampling` implementation to use. Defaults to
+    ///     `AVAssetFrameSampler()`; overridable for testing.
+    ///   - threshold: Maximum mean Hamming distance (out of 64) for two
+    ///     files to be grouped as duplicates.
+    /// - Returns: Groups of two or more perceptually-similar files.
+    private static func findByPerceptualHash(
+        _ urls: [URL],
+        sampler: any FrameSampling = AVAssetFrameSampler(),
+        threshold: Int = PerceptualHasher.defaultDistanceThreshold
+    ) async -> [DuplicateGroup] {
+        var vectors: [FileHashVector] = []
+
+        for url in urls {
+            let hashes = await PerceptualHasher.hashFile(
+                at: url,
+                sampler: sampler,
+                frameCount: PerceptualHasher.defaultFrameCount
+            )
+            guard !hashes.isEmpty else {
+                print(
+                    "[DuplicateDetector] Skipping \(url.lastPathComponent) for perceptual " +
+                    "matching: no decodable video frames (unsupported format, corrupt " +
+                    "stream, or zero/invalid duration)."
+                )
+                continue
+            }
+            vectors.append(FileHashVector(url: url, hashes: hashes))
+        }
+
+        return PerceptualHasher.groupByDistance(vectors, threshold: threshold).map { files in
+            let size = fileSize(for: files[0]) ?? 0
+            return DuplicateGroup(files: files, matchType: .perceptual, fileSize: size)
+        }
     }
 
     /// Returns the file size in bytes for the given URL, or `nil` on failure.

--- a/Sources/ConverterEngine/Utilities/PerceptualHasher.swift
+++ b/Sources/ConverterEngine/Utilities/PerceptualHasher.swift
@@ -1,0 +1,486 @@
+// ============================================================================
+// MeedyaConverter — PerceptualHasher (Issue #449)
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+
+import Foundation
+import CoreGraphics
+import AVFoundation
+
+// MARK: - FrameSampling
+
+/// Seam between "get representative frames out of a media file" and the pure
+/// hashing math in `PerceptualHasher` below.
+///
+/// Keeping this as a protocol means:
+/// 1. The pure DCT/hash/compare math can be unit-tested with zero media
+///    decode at all (synthetic pixel buffers only — see
+///    `PerceptualHasherTests`).
+/// 2. A future sampler (e.g. an ffmpeg-based frame extractor, once the
+///    #373 `SuiteCore` bindings land) can substitute for
+///    `AVAssetFrameSampler` without touching the hashing/grouping code.
+///
+/// Phase 11 — Duplicate File Detection (Issue #449)
+public protocol FrameSampling: Sendable {
+
+    /// Returns up to `count` representative frames from the asset at `url`,
+    /// spread across its duration.
+    ///
+    /// Never throws. Returns an empty array for anything that can't be
+    /// decoded — a missing file, a non-media file, a zero/invalid duration,
+    /// a corrupt stream. Callers are expected to log and skip rather than
+    /// treat an empty result as an exceptional condition (see
+    /// `DuplicateDetector`'s perceptual-match path).
+    func sampleFrames(from url: URL, count: Int) async -> [CGImage]
+}
+
+// MARK: - AVAssetFrameSampler
+
+/// Default `FrameSampling` implementation, built on `AVAssetImageGenerator`.
+///
+/// Samples frames at fixed percentages of the asset duration (see
+/// `PerceptualHasher.samplePositions(count:)`) rather than fixed timestamps,
+/// so the same relative frames are compared regardless of clip length.
+///
+/// ## Concurrency
+/// `AVAssetImageGenerator.copyCGImage(at:actualTime:)` is a synchronous,
+/// thread-blocking decode call — unlike `AVAsynchronousKeyValueLoading`'s
+/// `load(.duration)` (used below exactly as `DuplicateDetector
+/// .findBySimilarDuration` already does), it must never run directly on the
+/// calling actor, since this sampler is invoked from UI code
+/// (`DuplicateFinderView.performScan()`) whose enclosing `Task` inherits the
+/// main actor.
+///
+/// The frame-grab loop therefore runs inside a single `Task.detached`,
+/// mirroring the established blocking-work pattern used throughout the app
+/// (`ImageConversionView.startConversion`, `BurnSettingsView`,
+/// `ThumbnailCache.loadThumbnail`): only `Sendable` values cross the
+/// boundary — `URL` and `[Double]` offsets going in, `[CGImage]` coming out
+/// (`CGImage` is `@unchecked Sendable` in CoreGraphics — an immutable,
+/// thread-safe bitmap type since macOS 10.9). `AVAsset` /
+/// `AVAssetImageGenerator` instances are never captured across the
+/// boundary — because `AVAsset`'s Sendability is not guaranteed by the SDK,
+/// a fresh asset/generator pair is constructed *inside* the detached task
+/// instead of being built outside and captured in.
+///
+/// Phase 11 — Duplicate File Detection (Issue #449)
+public struct AVAssetFrameSampler: FrameSampling {
+
+    public init() {}
+
+    public func sampleFrames(from url: URL, count: Int) async -> [CGImage] {
+        guard count > 0 else { return [] }
+
+        // Non-blocking, structured-concurrency duration probe. Runs
+        // directly on the calling task — AVAsset property loading is
+        // implemented as genuine async I/O, not a blocking call, so it
+        // does not need `Task.detached`.
+        guard let duration = try? await AVURLAsset(url: url).load(.duration) else {
+            return []
+        }
+        let durationSeconds = CMTimeGetSeconds(duration)
+        guard durationSeconds.isFinite, durationSeconds > 0 else { return [] }
+
+        let offsets = PerceptualHasher.samplePositions(count: count).map { durationSeconds * $0 }
+
+        return await Task.detached(priority: .utility) {
+            let asset = AVURLAsset(url: url)
+            let generator = AVAssetImageGenerator(asset: asset)
+            generator.appliesPreferredTrackTransform = true
+            generator.requestedTimeToleranceBefore = .zero
+            generator.requestedTimeToleranceAfter = .zero
+
+            var images: [CGImage] = []
+            images.reserveCapacity(offsets.count)
+            for offset in offsets {
+                let time = CMTime(seconds: offset, preferredTimescale: 600)
+                if let cgImage = try? generator.copyCGImage(at: time, actualTime: nil) {
+                    images.append(cgImage)
+                }
+            }
+            return images
+        }.value
+    }
+}
+
+// MARK: - FileHashVector
+
+/// A file's perceptual-hash fingerprint: one 64-bit pHash per sampled frame,
+/// in sample-position order (see `PerceptualHasher.samplePositions(count:)`).
+///
+/// Phase 11 — Duplicate File Detection (Issue #449)
+public struct FileHashVector: Sendable {
+
+    /// The file this fingerprint belongs to.
+    public let url: URL
+
+    /// One pHash per successfully decoded/hashed sampled frame. May be
+    /// shorter than the requested frame count if some frames failed to
+    /// decode; never fabricated to compensate.
+    public let hashes: [UInt64]
+
+    public init(url: URL, hashes: [UInt64]) {
+        self.url = url
+        self.hashes = hashes
+    }
+}
+
+// MARK: - PerceptualHasher
+
+/// Pure perceptual-hash (pHash) math: grayscale reduction, a hand-rolled 2D
+/// DCT, hash extraction, Hamming-distance comparison, and duplicate
+/// grouping.
+///
+/// Every function below the frame-sampling seam is a **pure function** —
+/// no I/O, no media decode, no `AVFoundation`, no randomness — so it can be
+/// exercised directly in CI with synthetic pixel buffers (see
+/// `PerceptualHasherTests`), independent of whether the host is macOS.
+///
+/// ## Algorithm
+/// 1. A `CGImage` frame is downsampled to a 32×32 grayscale luma buffer
+///    (`grayscale32(from:)`).
+/// 2. A 2D DCT-II is applied to the 32×32 buffer (`dct2D(_:)`).
+/// 3. The top-left 8×8 block of low-frequency coefficients is taken.
+/// 4. The median of the 63 AC coefficients (the block excluding the DC
+///    term, which is typically far larger than every AC coefficient and
+///    would otherwise skew the threshold) is computed.
+/// 5. All 64 coefficients — DC included — are compared against that
+///    median to produce a 64-bit hash (`pHash(fromGray32:)`). This mirrors
+///    the widely-used Krawetz/"pHash.org" DCT hash construction.
+/// 6. Two frames are compared with `hammingDistance(_:_:)`; two files are
+///    compared with `meanHammingDistance(_:_:)` across their aligned
+///    per-frame hash vectors; a batch of files is clustered into duplicate
+///    groups with `groupByDistance(_:threshold:)`.
+///
+/// Phase 11 — Duplicate File Detection (Issue #449)
+public struct PerceptualHasher: Sendable {
+
+    // MARK: - Tunables
+
+    /// Default number of frames sampled per file.
+    public static let defaultFrameCount = 5
+
+    /// Default maximum mean Hamming distance (out of 64 possible bits) for
+    /// two files to be considered duplicates. Lower is stricter.
+    public static let defaultDistanceThreshold = 10
+
+    /// Side length (in pixels) of the grayscale buffer each frame is
+    /// reduced to before hashing.
+    public static let frameSide = 32
+
+    /// Side length (in coefficients) of the low-frequency DCT block used
+    /// to build the hash. `blockSide * blockSide` must equal 64 to produce
+    /// a `UInt64` hash.
+    public static let blockSide = 8
+
+    // MARK: - Sample Positions (pure)
+
+    /// Returns `count` fractional positions (each in `(0, 1)`) spread
+    /// across a clip's duration, evenly spaced between 10% and 90%.
+    ///
+    /// For the default `count` of 5 this yields exactly
+    /// `[0.10, 0.30, 0.50, 0.70, 0.90]`. Avoiding the very start/end of the
+    /// clip sidesteps black frames, fade-ins/outs, and title cards that
+    /// would otherwise dominate the hash of an entire file.
+    ///
+    /// - Parameter count: Number of positions to generate.
+    /// - Returns: Fractional offsets in ascending order; empty if
+    ///   `count <= 0`.
+    public static func samplePositions(count: Int) -> [Double] {
+        guard count > 0 else { return [] }
+        guard count > 1 else { return [0.5] }
+        let step = 0.8 / Double(count - 1)
+        return (0..<count).map { 0.1 + Double($0) * step }
+    }
+
+    // MARK: - Grayscale Reduction (impure — CoreGraphics only, no AVFoundation)
+
+    /// Downsamples a `CGImage` to a `frameSide` × `frameSide` (32×32)
+    /// 8-bit grayscale luma buffer, row-major, top-to-bottom.
+    ///
+    /// This step touches `CoreGraphics` but never `AVFoundation`, so while
+    /// it is not a *pure* function (it depends on platform bitmap
+    /// rendering), it needs no media decode and is not exercised by the
+    /// unit tests — `pHash(fromGray32:)` below is the tested, pure
+    /// boundary.
+    ///
+    /// - Parameter cgImage: The source frame.
+    /// - Returns: `frameSide * frameSide` grayscale bytes, or `nil` if the
+    ///   image is degenerate or the bitmap context could not be created.
+    public static func grayscale32(from cgImage: CGImage) -> [UInt8]? {
+        guard cgImage.width > 0, cgImage.height > 0 else { return nil }
+
+        let side = frameSide
+        guard let context = CGContext(
+            data: nil,
+            width: side,
+            height: side,
+            bitsPerComponent: 8,
+            bytesPerRow: side,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        ) else { return nil }
+
+        context.interpolationQuality = .high
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: side, height: side))
+
+        guard let rawData = context.data else { return nil }
+        let buffer = rawData.bindMemory(to: UInt8.self, capacity: side * side)
+        return Array(UnsafeBufferPointer(start: buffer, count: side * side))
+    }
+
+    // MARK: - Discrete Cosine Transform (pure)
+
+    /// Applies a 2D DCT-II to a square matrix via two passes of the 1D
+    /// DCT-II (rows, then columns) — the standard separable-transform
+    /// construction, and the only way a 32×32 DCT stays cheap
+    /// (`O(2·N³)` instead of a naive `O(N⁴)`).
+    ///
+    /// No normalisation constants are applied (i.e. this is not an
+    /// orthonormal DCT) — `pHash(fromGray32:)` only ever compares
+    /// coefficients against each other's median, so a consistent scale
+    /// factor is irrelevant to the result.
+    ///
+    /// For a **constant** input matrix, the DCT-II basis functions are
+    /// exactly orthogonal to the constant (DC) function for every
+    /// non-zero frequency, so every coefficient except `[0][0]` is exactly
+    /// (up to floating-point rounding) zero — all the energy concentrates
+    /// in the DC term. `PerceptualHasherTests` asserts exactly this.
+    ///
+    /// - Parameter matrix: A square (`N` × `N`) matrix of samples.
+    /// - Returns: The `N` × `N` matrix of DCT-II coefficients, in the same
+    ///   row/column layout (low frequencies toward `[0][0]`). Returns the
+    ///   input unchanged if it is empty or not square.
+    static func dct2D(_ matrix: [[Double]]) -> [[Double]] {
+        let n = matrix.count
+        guard n > 0, matrix.allSatisfy({ $0.count == n }) else { return matrix }
+
+        let rowsTransformed = matrix.map { dct1D($0) }
+
+        var result = [[Double]](repeating: [Double](repeating: 0, count: n), count: n)
+        for col in 0..<n {
+            let column = (0..<n).map { rowsTransformed[$0][col] }
+            let transformedColumn = dct1D(column)
+            for row in 0..<n {
+                result[row][col] = transformedColumn[row]
+            }
+        }
+        return result
+    }
+
+    /// 1D DCT-II: `X_k = Σ_i x_i · cos( (π / N) · (i + 0.5) · k )`.
+    private static func dct1D(_ input: [Double]) -> [Double] {
+        let n = input.count
+        guard n > 0 else { return [] }
+
+        var output = [Double](repeating: 0, count: n)
+        let scale = Double.pi / Double(n)
+        for k in 0..<n {
+            var sum = 0.0
+            for i in 0..<n {
+                sum += input[i] * cos(scale * (Double(i) + 0.5) * Double(k))
+            }
+            output[k] = sum
+        }
+        return output
+    }
+
+    // MARK: - Hash (pure — the primary CI-tested entry point)
+
+    /// Computes a 64-bit perceptual hash from a raw 32×32 grayscale luma
+    /// buffer.
+    ///
+    /// This is the pure entry point exercised directly by
+    /// `PerceptualHasherTests` — it takes no `CGImage`, no `AVFoundation`
+    /// type, nothing platform-specific: just 1,024 bytes in, one `UInt64`
+    /// out, always the same output for the same input.
+    ///
+    /// - Parameter pixels: Exactly `frameSide * frameSide` (1,024)
+    ///   grayscale bytes, row-major, top-to-bottom — as produced by
+    ///   `grayscale32(from:)`.
+    /// - Returns: A 64-bit hash; bit `i` corresponds to row-major position
+    ///   `i` (`i / blockSide`, `i % blockSide`) of the low-frequency 8×8
+    ///   DCT block, set when that coefficient exceeds the AC-coefficient
+    ///   median.
+    public static func pHash(fromGray32 pixels: [UInt8]) -> UInt64 {
+        precondition(
+            pixels.count == frameSide * frameSide,
+            "pHash(fromGray32:) requires exactly \(frameSide * frameSide) bytes " +
+            "(a \(frameSide)x\(frameSide) grayscale buffer); got \(pixels.count)."
+        )
+
+        var matrix = [[Double]](repeating: [Double](repeating: 0, count: frameSide), count: frameSide)
+        for row in 0..<frameSide {
+            for col in 0..<frameSide {
+                matrix[row][col] = Double(pixels[row * frameSide + col])
+            }
+        }
+
+        let frequencies = dct2D(matrix)
+
+        // Top-left blockSide x blockSide block = the lowest-frequency
+        // coefficients, row-major. Index 0 is the DC term.
+        var block: [Double] = []
+        block.reserveCapacity(blockSide * blockSide)
+        for row in 0..<blockSide {
+            for col in 0..<blockSide {
+                block.append(frequencies[row][col])
+            }
+        }
+
+        // Median of the AC coefficients only (DC excluded — it is
+        // typically far larger than every AC coefficient and would
+        // otherwise dominate/skew the threshold). All 64 coefficients,
+        // DC included, are then compared against this threshold.
+        let threshold = median(of: Array(block.dropFirst()))
+
+        var hash: UInt64 = 0
+        for (index, value) in block.enumerated() where value > threshold {
+            hash |= (UInt64(1) << UInt64(index))
+        }
+        return hash
+    }
+
+    /// Sorted-array median (average of the two middle elements for an
+    /// even count). Pure, deterministic, no randomness.
+    private static func median(of values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let mid = sorted.count / 2
+        if sorted.count.isMultiple(of: 2) {
+            return (sorted[mid - 1] + sorted[mid]) / 2
+        }
+        return sorted[mid]
+    }
+
+    // MARK: - Comparison (pure)
+
+    /// Bit-level Hamming distance between two 64-bit hashes (0…64).
+    public static func hammingDistance(_ a: UInt64, _ b: UInt64) -> Int {
+        (a ^ b).nonzeroBitCount
+    }
+
+    /// Mean Hamming distance between two files' per-frame hash vectors,
+    /// aligned by sample position (index `i` in `a` is compared against
+    /// index `i` in `b`, since both are produced from the same
+    /// `samplePositions(count:)` fractions).
+    ///
+    /// Compares only the overlapping prefix (`min(a.count, b.count)`
+    /// frames) — if a file has fewer successfully-decoded frames than its
+    /// counterpart, the shorter vector's positions are compared and any
+    /// tail is ignored, rather than fabricating hashes for missing frames.
+    ///
+    /// - Returns: Mean distance across the overlapping frames, or
+    ///   `Double(UInt64.bitWidth)` (64 — the maximum possible distance) if
+    ///   there is no overlap (either vector is empty), so files with no
+    ///   comparable frames are never mistaken for a close match.
+    public static func meanHammingDistance(_ a: [UInt64], _ b: [UInt64]) -> Double {
+        let n = min(a.count, b.count)
+        guard n > 0 else { return Double(UInt64.bitWidth) }
+
+        var total = 0
+        for i in 0..<n {
+            total += hammingDistance(a[i], b[i])
+        }
+        return Double(total) / Double(n)
+    }
+
+    // MARK: - Grouping (pure)
+
+    /// Transitively clusters files whose mean Hamming distance is within
+    /// `threshold`, using union-find so that A≈B and B≈C groups A, B, and
+    /// C together even if A and C alone would fall just outside the
+    /// threshold.
+    ///
+    /// - Parameters:
+    ///   - vectors: One `FileHashVector` per candidate file. Vectors with
+    ///     an empty `hashes` array (nothing decodable) are still accepted
+    ///     but can never match anything (see `meanHammingDistance`'s
+    ///     no-overlap fallback), so they are naturally excluded from every
+    ///     result group.
+    ///   - threshold: Maximum mean Hamming distance (out of 64) for two
+    ///     files to be considered duplicates. Defaults to
+    ///     `defaultDistanceThreshold`.
+    /// - Returns: Groups of two or more file URLs, in first-seen order;
+    ///   singletons are omitted. Deterministic for a given input order —
+    ///   no dictionary/set iteration order is relied upon.
+    public static func groupByDistance(
+        _ vectors: [FileHashVector],
+        threshold: Int = defaultDistanceThreshold
+    ) -> [[URL]] {
+        guard vectors.count > 1 else { return [] }
+
+        var parent = Array(0..<vectors.count)
+        func find(_ x: Int) -> Int {
+            var x = x
+            while parent[x] != x {
+                parent[x] = parent[parent[x]]
+                x = parent[x]
+            }
+            return x
+        }
+        func union(_ a: Int, _ b: Int) {
+            let rootA = find(a)
+            let rootB = find(b)
+            if rootA != rootB {
+                parent[rootA] = rootB
+            }
+        }
+
+        for i in 0..<vectors.count {
+            for j in (i + 1)..<vectors.count {
+                let distance = meanHammingDistance(vectors[i].hashes, vectors[j].hashes)
+                if distance <= Double(threshold) {
+                    union(i, j)
+                }
+            }
+        }
+
+        // Build groups in first-seen order rather than iterating a
+        // Dictionary's `.values` (unspecified order) so results are
+        // deterministic for a given input order.
+        var rootToGroupIndex: [Int: Int] = [:]
+        var groups: [[Int]] = []
+        for i in 0..<vectors.count {
+            let root = find(i)
+            if let groupIndex = rootToGroupIndex[root] {
+                groups[groupIndex].append(i)
+            } else {
+                rootToGroupIndex[root] = groups.count
+                groups.append([i])
+            }
+        }
+
+        return groups
+            .filter { $0.count >= 2 }
+            .map { indices in indices.map { vectors[$0].url } }
+    }
+
+    // MARK: - End-to-End Convenience (impure — media I/O via the sampler)
+
+    /// Samples and hashes a single file: `sampler.sampleFrames` →
+    /// `grayscale32(from:)` → `pHash(fromGray32:)`.
+    ///
+    /// Frames that fail to decode or fail grayscale conversion are simply
+    /// omitted (never fabricated), so the returned array may be shorter
+    /// than `frameCount` — or empty, if nothing decoded at all.
+    ///
+    /// - Parameters:
+    ///   - url: The candidate file.
+    ///   - sampler: The `FrameSampling` implementation to use. Defaults to
+    ///     `AVAssetFrameSampler()`.
+    ///   - frameCount: Number of frames to request. Defaults to
+    ///     `defaultFrameCount`.
+    /// - Returns: One pHash per successfully sampled+hashed frame, in
+    ///   sample-position order.
+    public static func hashFile(
+        at url: URL,
+        sampler: any FrameSampling = AVAssetFrameSampler(),
+        frameCount: Int = defaultFrameCount
+    ) async -> [UInt64] {
+        let frames = await sampler.sampleFrames(from: url, count: frameCount)
+        return frames.compactMap(grayscale32).map(pHash(fromGray32:))
+    }
+}

--- a/Sources/MeedyaConverter/Views/DuplicateFinderView.swift
+++ b/Sources/MeedyaConverter/Views/DuplicateFinderView.swift
@@ -30,6 +30,10 @@ struct DuplicateFinderView: View {
     /// The discovered duplicate groups from the most recent scan.
     @State private var duplicateGroups: [DuplicateGroup] = []
 
+    /// Maximum mean Hamming distance (out of 64) for `.perceptual` matching.
+    /// Only consulted when `selectedMethod == .perceptual`.
+    @State private var perceptualThreshold: Double = Double(PerceptualHasher.defaultDistanceThreshold)
+
     /// Tracks which file URLs the user has marked for deletion.
     @State private var markedForDeletion: Set<URL> = []
 
@@ -61,6 +65,9 @@ struct DuplicateFinderView: View {
         VStack(alignment: .leading, spacing: 16) {
             headerSection
             controlsSection
+            if selectedMethod == .perceptual {
+                perceptualThresholdSection
+            }
             if isScanning {
                 ProgressView("Scanning for duplicates…")
                     .padding()
@@ -106,16 +113,7 @@ struct DuplicateFinderView: View {
             }
 
             Picker("Method:", selection: $selectedMethod) {
-                // TODO(#449): re-enable when perceptual-hash matching is
-                // implemented. `.perceptual` is filtered out of the
-                // selectable options here because
-                // `DuplicateDetector.findDuplicates(in:method:)` returns an
-                // empty result for it unconditionally
-                // (DuplicateDetector.swift:101-104) — there is no pHash
-                // implementation behind it yet, so exposing it would let
-                // the user "successfully" run a scan that can never find
-                // anything, with no indication anything is wrong.
-                ForEach(MatchType.allCases.filter { $0 != .perceptual }, id: \.self) { method in
+                ForEach(MatchType.allCases, id: \.self) { method in
                     Text(method.rawValue).tag(method)
                 }
             }
@@ -127,6 +125,26 @@ struct DuplicateFinderView: View {
             }
             .disabled(selectedDirectory == nil || isScanning)
             .buttonStyle(.borderedProminent)
+        }
+    }
+
+    // MARK: - Perceptual Threshold
+
+    /// Tunable similarity threshold for `.perceptual` matching, shown only
+    /// when that method is selected. Higher values match more loosely
+    /// (more false positives); lower values match more strictly (more
+    /// false negatives).
+    private var perceptualThresholdSection: some View {
+        HStack {
+            Text("Similarity threshold:")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Slider(value: $perceptualThreshold, in: 0...32, step: 1)
+            Text("\(Int(perceptualThreshold))/64")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 40, alignment: .trailing)
+                .monospacedDigit()
         }
     }
 
@@ -204,7 +222,11 @@ struct DuplicateFinderView: View {
 
         let fileURLs = collectFiles(in: directory)
 
-        let results = await DuplicateDetector.findDuplicates(in: fileURLs, method: selectedMethod)
+        let results = await DuplicateDetector.findDuplicates(
+            in: fileURLs,
+            method: selectedMethod,
+            perceptualThreshold: Int(perceptualThreshold)
+        )
         duplicateGroups = results
         isScanning = false
     }

--- a/Tests/ConverterEngineTests/PerceptualHasherTests.swift
+++ b/Tests/ConverterEngineTests/PerceptualHasherTests.swift
@@ -1,0 +1,375 @@
+// ============================================================================
+// MeedyaConverter — PerceptualHasherTests
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// ============================================================================
+
+import Foundation
+import XCTest
+@testable import ConverterEngine
+
+/// Regression tests for `PerceptualHasher` — the pure DCT/pHash/compare/
+/// group math behind Issue #449's perceptual duplicate matching.
+///
+/// Every test here works on synthetic, hand-constructed pixel buffers or
+/// raw `UInt64` hash values. None of them touch `CGImage`, `AVFoundation`,
+/// or any file on disk — they exercise exactly the pure boundary the
+/// design calls out: `pHash(fromGray32:)`, `dct2D(_:)`,
+/// `hammingDistance(_:_:)`, `meanHammingDistance(_:_:)`,
+/// `groupByDistance(_:threshold:)`, and `samplePositions(count:)`.
+///
+/// Numeric expectations for the DCT-derived tests (gradient-vs-inverted,
+/// perturbation robustness, constant-matrix DC concentration) were
+/// cross-checked against an independent Python re-implementation of the
+/// exact same algorithm before being written here, then given generous
+/// safety margins to absorb any last-bit differences between platform
+/// `cos()` implementations — so the assertions check qualitative
+/// properties ("large", "small", "near zero") rather than brittle exact
+/// values, except where the two sides are byte-for-byte identical inputs
+/// (which must always produce byte-for-byte identical output on any
+/// platform) or hand-picked integer bit patterns (which involve no
+/// floating-point math at all).
+final class PerceptualHasherTests: XCTestCase {
+
+    // MARK: - Synthetic Buffer Builders
+
+    private let side = PerceptualHasher.frameSide // 32
+
+    /// A smooth horizontal gradient (row-invariant, columns ramp 0→255).
+    /// Deliberately *not* flat, so the DCT has real AC energy to hash.
+    private func gradientBuffer() -> [UInt8] {
+        var buffer = [UInt8](repeating: 0, count: side * side)
+        for row in 0..<side {
+            for col in 0..<side {
+                buffer[row * side + col] = UInt8(col * 255 / (side - 1))
+            }
+        }
+        return buffer
+    }
+
+    /// Photographic negative of a buffer (`255 - value` per pixel).
+    private func invertedBuffer(_ buffer: [UInt8]) -> [UInt8] {
+        buffer.map { 255 - $0 }
+    }
+
+    /// A busier deterministic pattern (varies in both row and column, no
+    /// two adjacent rows identical) so single-pixel perturbations exercise
+    /// realistic, non-degenerate DCT coefficients.
+    private func texturedBuffer() -> [UInt8] {
+        var buffer = [UInt8](repeating: 0, count: side * side)
+        for row in 0..<side {
+            for col in 0..<side {
+                let value = (row * 37 + col * 59 + (row * col) % 23) % 256
+                buffer[row * side + col] = UInt8(value)
+            }
+        }
+        return buffer
+    }
+
+    /// An unrelated deterministic remap of another buffer's pixels (not a
+    /// simple negation), used as a "definitely different image" fixture.
+    private func unrelatedBuffer(from buffer: [UInt8]) -> [UInt8] {
+        buffer.map { UInt8((Int($0) * 173 + 41) % 256) }
+    }
+
+    /// Returns a copy of `buffer` with `delta` added (clamped to
+    /// `0...255`) at each of `indices` — a small, localised perturbation.
+    private func perturbedBuffer(_ buffer: [UInt8], indices: [Int], delta: Int) -> [UInt8] {
+        var copy = buffer
+        for index in indices {
+            let newValue = Int(copy[index]) + delta
+            copy[index] = UInt8(max(0, min(255, newValue)))
+        }
+        return copy
+    }
+
+    // MARK: - pHash: Identity
+
+    func test_pHash_identicalBuffers_zeroDistance() {
+        let buffer = gradientBuffer()
+        let hashA = PerceptualHasher.pHash(fromGray32: buffer)
+        let hashB = PerceptualHasher.pHash(fromGray32: buffer)
+
+        XCTAssertEqual(hashA, hashB, "Hashing the exact same buffer twice must be deterministic.")
+        XCTAssertEqual(PerceptualHasher.hammingDistance(hashA, hashB), 0)
+    }
+
+    func test_pHash_isDeterministicAcrossRepeatedCalls() {
+        let buffer = texturedBuffer()
+        let hashes = (0..<5).map { _ in PerceptualHasher.pHash(fromGray32: buffer) }
+        XCTAssertEqual(Set(hashes).count, 1, "pHash must be a pure function of its input.")
+    }
+
+    // MARK: - pHash: Large Distance for Genuinely Different Images
+
+    func test_pHash_gradientVsInverted_largeDistance() {
+        let gradient = gradientBuffer()
+        let inverted = invertedBuffer(gradient)
+
+        let hashGradient = PerceptualHasher.pHash(fromGray32: gradient)
+        let hashInverted = PerceptualHasher.pHash(fromGray32: inverted)
+
+        let distance = PerceptualHasher.hammingDistance(hashGradient, hashInverted)
+        // A photographic negative flips the sign of every AC coefficient,
+        // which flips nearly every thresholded bit — expect the distance
+        // to sit far above the default duplicate threshold (10).
+        XCTAssertGreaterThan(
+            distance, 20,
+            "A gradient and its photographic negative should hash to very different fingerprints."
+        )
+        XCTAssertGreaterThan(
+            Double(distance), Double(PerceptualHasher.defaultDistanceThreshold),
+            "Inverted images must not be grouped as duplicates under the default threshold."
+        )
+    }
+
+    func test_pHash_unrelatedPatterns_largeDistance() {
+        let textured = texturedBuffer()
+        let unrelated = unrelatedBuffer(from: textured)
+
+        let distance = PerceptualHasher.hammingDistance(
+            PerceptualHasher.pHash(fromGray32: textured),
+            PerceptualHasher.pHash(fromGray32: unrelated)
+        )
+        XCTAssertGreaterThan(distance, 15, "Unrelated images should not hash close together.")
+    }
+
+    // MARK: - pHash: Small Distance for Minor Perturbations
+
+    func test_pHash_smallPerturbation_smallDistance() {
+        let original = texturedBuffer()
+        let perturbed = perturbedBuffer(original, indices: [0, 100, 500, 777, 1023], delta: 10)
+
+        let distance = PerceptualHasher.hammingDistance(
+            PerceptualHasher.pHash(fromGray32: original),
+            PerceptualHasher.pHash(fromGray32: perturbed)
+        )
+        XCTAssertLessThanOrEqual(
+            distance, PerceptualHasher.defaultDistanceThreshold,
+            "A handful of small pixel-value tweaks should stay within the duplicate threshold."
+        )
+    }
+
+    // MARK: - dct2D: Known Simple Pattern (Constant Buffer)
+
+    func test_dct2D_constantMatrix_allEnergyConcentratesInDC() {
+        let value = 7.0
+        let matrix = [[Double]](repeating: [Double](repeating: value, count: side), count: side)
+
+        let frequencies = PerceptualHasher.dct2D(matrix)
+
+        // DC term: sum of `value` over every cell, since cos(0) == 1 for
+        // every contributing term in both DCT passes.
+        let expectedDC = value * Double(side * side)
+        XCTAssertEqual(frequencies[0][0], expectedDC, accuracy: 1e-6)
+
+        // Every AC (non-DC) coefficient must be ~0: the DCT-II basis
+        // functions are exactly orthogonal to a constant signal.
+        for row in 0..<side {
+            for col in 0..<side where !(row == 0 && col == 0) {
+                XCTAssertEqual(
+                    frequencies[row][col], 0, accuracy: 1e-6,
+                    "AC coefficient [\(row)][\(col)] should be ~0 for a constant input."
+                )
+            }
+        }
+    }
+
+    func test_dct2D_emptyMatrix_returnsEmpty() {
+        XCTAssertTrue(PerceptualHasher.dct2D([]).isEmpty)
+    }
+
+    func test_dct2D_nonSquareMatrix_returnsUnchanged() {
+        // Row lengths (3, 2) don't match the row count (2) → not square;
+        // the pure function must fail safe rather than crash or truncate.
+        let jagged: [[Double]] = [[1, 2, 3], [4, 5]]
+        let result = PerceptualHasher.dct2D(jagged)
+        XCTAssertEqual(result.count, jagged.count)
+        for (lhs, rhs) in zip(result, jagged) {
+            XCTAssertEqual(lhs, rhs)
+        }
+    }
+
+    // MARK: - hammingDistance
+
+    func test_hammingDistance_identicalValues_zero() {
+        for value: UInt64 in [0, .max, 0x0F0F_0F0F_0F0F_0F0F, 1] {
+            XCTAssertEqual(PerceptualHasher.hammingDistance(value, value), 0)
+        }
+    }
+
+    func test_hammingDistance_allBitsDiffer_sixtyFour() {
+        XCTAssertEqual(PerceptualHasher.hammingDistance(0, .max), 64)
+    }
+
+    func test_hammingDistance_knownBitPattern() {
+        // 0b1010 vs 0b0101 — all 4 low bits differ, nothing else set.
+        XCTAssertEqual(PerceptualHasher.hammingDistance(0b1010, 0b0101), 4)
+    }
+
+    func test_hammingDistance_isSymmetric() {
+        let a: UInt64 = 0x1234_5678_9ABC_DEF0
+        let b: UInt64 = 0x0FED_CBA9_8765_4321
+        XCTAssertEqual(
+            PerceptualHasher.hammingDistance(a, b),
+            PerceptualHasher.hammingDistance(b, a)
+        )
+    }
+
+    // MARK: - meanHammingDistance
+
+    func test_meanHammingDistance_alignedFrames_averagesPerFrameDistance() {
+        let a: [UInt64] = [0, 0, 0]
+        // Distances vs `a`: 1 bit, 2 bits, 3 bits set respectively.
+        let b: [UInt64] = [0b1, 0b11, 0b111]
+
+        XCTAssertEqual(PerceptualHasher.meanHammingDistance(a, b), 2.0, accuracy: 1e-9)
+    }
+
+    func test_meanHammingDistance_differingLengths_usesOverlapOnly() {
+        let a: [UInt64] = [0, 0, 0, 0]
+        let b: [UInt64] = [0xFF, 0] // only 2 frames
+
+        // Only the first 2 entries of `a` are compared: distances 8 and 0.
+        XCTAssertEqual(PerceptualHasher.meanHammingDistance(a, b), 4.0, accuracy: 1e-9)
+    }
+
+    func test_meanHammingDistance_noOverlap_returnsMaxDistance() {
+        XCTAssertEqual(PerceptualHasher.meanHammingDistance([], [0, 0]), 64.0, accuracy: 1e-9)
+        XCTAssertEqual(PerceptualHasher.meanHammingDistance([0], []), 64.0, accuracy: 1e-9)
+        XCTAssertEqual(PerceptualHasher.meanHammingDistance([], []), 64.0, accuracy: 1e-9)
+    }
+
+    // MARK: - groupByDistance
+
+    func test_groupByDistance_closeFilesGroupTogether_distantFileExcluded() {
+        let fileA = URL(fileURLWithPath: "/tmp/a.mp4")
+        let fileB = URL(fileURLWithPath: "/tmp/b.mp4")
+        let fileC = URL(fileURLWithPath: "/tmp/c.mp4")
+
+        let gradient = gradientBuffer()
+        let closeHash = PerceptualHasher.pHash(fromGray32: gradient)
+        let farHash = PerceptualHasher.pHash(fromGray32: unrelatedBuffer(from: gradient))
+
+        let vectors = [
+            FileHashVector(url: fileA, hashes: [closeHash]),
+            FileHashVector(url: fileB, hashes: [closeHash]),
+            FileHashVector(url: fileC, hashes: [farHash]),
+        ]
+
+        let groups = PerceptualHasher.groupByDistance(vectors, threshold: PerceptualHasher.defaultDistanceThreshold)
+
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(Set(groups[0]), Set([fileA, fileB]))
+        XCTAssertFalse(groups.flatMap { $0 }.contains(fileC))
+    }
+
+    func test_groupByDistance_transitiveClustering_bridgesBeyondDirectThreshold() {
+        let fileA = URL(fileURLWithPath: "/tmp/a.mp4")
+        let fileB = URL(fileURLWithPath: "/tmp/b.mp4")
+        let fileC = URL(fileURLWithPath: "/tmp/c.mp4")
+
+        // Hand-picked bit patterns — no DCT/floating-point involved, so
+        // the distances below are exact by construction:
+        //   hashA = 0
+        //   hashB = bits 0..7 set        → distance(A, B) = 8
+        //   hashC = hashB ^ bits 8..16 set → distance(B, C) = 9
+        // giving distance(A, C) = popcount(bits 0..16 set) = 17.
+        let hashA: UInt64 = 0
+        let hashB: UInt64 = 0x0000_0000_0000_00FF // bits 0-7
+        let bits8Through16: UInt64 = 0x0000_0000_0001_FF00 // bits 8-16 (9 bits)
+        let hashC: UInt64 = hashB ^ bits8Through16
+
+        XCTAssertEqual(PerceptualHasher.hammingDistance(hashA, hashB), 8)
+        XCTAssertEqual(PerceptualHasher.hammingDistance(hashB, hashC), 9)
+        XCTAssertEqual(PerceptualHasher.hammingDistance(hashA, hashC), 17)
+
+        let threshold = 10 // A-B and B-C are within threshold; A-C alone is not.
+        let vectors = [
+            FileHashVector(url: fileA, hashes: [hashA]),
+            FileHashVector(url: fileB, hashes: [hashB]),
+            FileHashVector(url: fileC, hashes: [hashC]),
+        ]
+
+        let groups = PerceptualHasher.groupByDistance(vectors, threshold: threshold)
+
+        XCTAssertEqual(groups.count, 1, "A-B and B-C should transitively merge into a single group.")
+        XCTAssertEqual(Set(groups[0]), Set([fileA, fileB, fileC]))
+    }
+
+    func test_groupByDistance_thresholdBoundary_lessThanOrEqualIncluded() {
+        let fileA = URL(fileURLWithPath: "/tmp/a.mp4")
+        let fileB = URL(fileURLWithPath: "/tmp/b.mp4")
+
+        // Exactly 10 bits differ.
+        let hashA: UInt64 = 0
+        let hashB: UInt64 = 0x0000_0000_0000_03FF // 10 low bits set
+        XCTAssertEqual(PerceptualHasher.hammingDistance(hashA, hashB), 10)
+
+        let vectors = [
+            FileHashVector(url: fileA, hashes: [hashA]),
+            FileHashVector(url: fileB, hashes: [hashB]),
+        ]
+
+        let grouped = PerceptualHasher.groupByDistance(vectors, threshold: 10)
+        XCTAssertEqual(grouped.count, 1, "A distance exactly equal to the threshold must still be grouped (<=).")
+
+        let notGrouped = PerceptualHasher.groupByDistance(vectors, threshold: 9)
+        XCTAssertTrue(notGrouped.isEmpty, "A distance one above the threshold must not be grouped.")
+    }
+
+    func test_groupByDistance_singleFile_returnsNoGroups() {
+        let vectors = [FileHashVector(url: URL(fileURLWithPath: "/tmp/a.mp4"), hashes: [0])]
+        XCTAssertTrue(PerceptualHasher.groupByDistance(vectors).isEmpty)
+    }
+
+    func test_groupByDistance_emptyInput_returnsNoGroups() {
+        XCTAssertTrue(PerceptualHasher.groupByDistance([]).isEmpty)
+    }
+
+    func test_groupByDistance_filesWithNoHashes_neverGroup() {
+        // A file with zero decoded frames (represented as an empty hash
+        // vector, per DuplicateDetector's "skip, don't fabricate" contract)
+        // must never be treated as matching anything, including another
+        // equally-empty file.
+        let fileA = URL(fileURLWithPath: "/tmp/a.mp4")
+        let fileB = URL(fileURLWithPath: "/tmp/b.mp4")
+        let vectors = [
+            FileHashVector(url: fileA, hashes: []),
+            FileHashVector(url: fileB, hashes: []),
+        ]
+        XCTAssertTrue(PerceptualHasher.groupByDistance(vectors).isEmpty)
+    }
+
+    // MARK: - samplePositions
+
+    func test_samplePositions_defaultFive_matchesTenThroughNinetyPercentSpec() {
+        let positions = PerceptualHasher.samplePositions(count: 5)
+        let expected = [0.10, 0.30, 0.50, 0.70, 0.90]
+
+        XCTAssertEqual(positions.count, expected.count)
+        for (actual, wanted) in zip(positions, expected) {
+            XCTAssertEqual(actual, wanted, accuracy: 1e-9)
+        }
+    }
+
+    func test_samplePositions_countOne_returnsMidpoint() {
+        XCTAssertEqual(PerceptualHasher.samplePositions(count: 1), [0.5])
+    }
+
+    func test_samplePositions_nonPositiveCount_returnsEmpty() {
+        XCTAssertTrue(PerceptualHasher.samplePositions(count: 0).isEmpty)
+        XCTAssertTrue(PerceptualHasher.samplePositions(count: -3).isEmpty)
+    }
+
+    func test_samplePositions_isStrictlyAscendingAndInBounds() {
+        let positions = PerceptualHasher.samplePositions(count: 7)
+        XCTAssertEqual(positions.count, 7)
+        for position in positions {
+            XCTAssertGreaterThan(position, 0)
+            XCTAssertLessThan(position, 1)
+        }
+        for i in 1..<positions.count {
+            XCTAssertGreaterThan(positions[i], positions[i - 1])
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **#449** perceptual-hash duplicate matching *properly* (per original spec) — `DuplicateDetector.findDuplicates(.perceptual)` previously returned `[]`.

New `PerceptualHasher`: `FrameSampling` protocol seam + `AVAssetFrameSampler` (samples 5 frames at 10/30/50/70/90% via `AVAssetImageGenerator`), then pure math — 32×32 grayscale → separable DCT-II → top-left 8×8 low-freq block → median-threshold → 64-bit pHash; Hamming-distance grouping via union-find. Wired into `DuplicateDetector`; the Perceptual option is un-hidden in `DuplicateFinderView` with a distance-threshold slider.

## Changes Made

- [x] `PerceptualHasher.swift` (new) — sampler protocol + AVFoundation sampler; **pure** `pHash(fromGray32:)`/`dct2D`/`hammingDistance`/`groupByDistance`
- [x] `DuplicateDetector.findByPerceptualHash` wired (skips undecodable files honestly, never fabricates)
- [x] `DuplicateFinderView` — removed the `.filter { $0 != .perceptual }` hide; added threshold slider
- [x] **24 unit tests** (`PerceptualHasherTests.swift`) on synthetic buffers — identity/determinism, DCT correctness, Hamming, transitive grouping — numerically cross-checked vs an independent Python impl (with margins for glibc↔Darwin `cos()` ULP diffs)

## Testing Done

CI is the gate (macOS-only) — incl. **security checks** (CodeQL, Dependency Review, pin-hygiene). Flagged for CI: `AVAssetImageGenerator.copyCGImage(at:actualTime:)` label; `CGContext` gray init; `AVURLAsset.load(.duration)` chaining.

- [ ] Build & Test (macOS) · CodeQL · Review Dependencies · pin hygiene

## Related Issues

Closes #449; evidence for closed-in-error #290 to follow.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NF44GLcMisedfvxHzhscJQ)_