### PR TITLE
Bundle 3: execute DualDynamicHDR, stats pipeline, CSV export, AnimatedImage (#448, #370, #284, #363, #321)

### DIFF
--- a/Sources/ConverterEngine/Encoding/DualDynamicHDRPipelineExecutor.swift
+++ b/Sources/ConverterEngine/Encoding/DualDynamicHDRPipelineExecutor.swift
@@ -1,0 +1,278 @@
+// ============================================================================
+// MeedyaConverter — DualDynamicHDRPipelineExecutor
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// MARK: - File Overview
+// ---------------------------------------------------------------------------
+// `DualDynamicHDRPipeline.buildPipelineSteps(...)` (issue #370) already
+// builds a fully-formed, ordered list of `PipelineStepDescriptor`s — each
+// carrying a real tool name, real argument array, and real input/output
+// paths — but nothing in the app ever ran them; `DualDynamicHDRView
+// .startConversion()` set `isConverting = true` and stopped, per a comment
+// noting "actual execution would be performed by the EncodingEngine".
+//
+// This file is that execution layer. It does not invent any new process-
+// spawning logic: each step is dispatched to the *existing*, already-tested
+// runners —
+//   - `tool == "dovi_tool"`      → `DoviToolWrapper.run(arguments:)`
+//   - `tool == "hdr10plus_tool"` → `HDR10PlusToolWrapper.run(arguments:)`
+//   - `tool == "internal"`       → `DualDynamicHDRPipeline
+//                                    .convertDVMetadataToHDR10Plus(...)`
+//   - `tool == "ffmpeg"`         → `FFmpegProcessController.startEncoding`
+//                                    (the five-tier HLG target's PQ→HLG
+//                                    base-layer pass; the four-tier target
+//                                    never produces this step)
+// via `DualDynamicHDRToolStepRunner`, the default (real) implementation of
+// the `DualDynamicHDRStepRunning` protocol. `DualDynamicHDRPipelineExecutor`
+// itself only sequences steps, reports progress, aborts on the first
+// failure, and cleans up intermediate temp files — logic that is pure
+// enough to unit-test with a mock `DualDynamicHDRStepRunning` and no real
+// dovi_tool/hdr10plus_tool/ffmpeg binaries, matching the "no real tools in
+// CI" constraint.
+// ---------------------------------------------------------------------------
+
+import Foundation
+
+// MARK: - DualDynamicHDRPipelineExecutorError
+
+/// Errors surfaced by `DualDynamicHDRPipelineExecutor`.
+public enum DualDynamicHDRPipelineExecutorError: LocalizedError, Sendable, Equatable {
+    /// A pipeline step failed. `underlying` is the tool's own error text
+    /// (e.g. dovi_tool/hdr10plus_tool stderr) — never fabricated.
+    case stepFailed(stepNumber: Int, tool: String, description: String, underlying: String)
+
+    /// A step named a tool the runner has no dispatch case for.
+    case unsupportedTool(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .stepFailed(stepNumber, tool, description, underlying):
+            return "Step \(stepNumber) (\(tool) — \(description)) failed: \(underlying)"
+        case .unsupportedTool(let tool):
+            return "Dual dynamic HDR pipeline step references an unsupported tool \"\(tool)\"."
+        }
+    }
+}
+
+// MARK: - DualDynamicHDRStepRunning
+
+/// Abstraction over "run one pipeline step", so `DualDynamicHDRPipelineExecutor`
+/// can be unit-tested with a mock — sequencing, failure-abort, and cleanup —
+/// without invoking real dovi_tool / hdr10plus_tool / ffmpeg binaries.
+///
+/// `DualDynamicHDRToolStepRunner` (below) is the real, production
+/// implementation; tests substitute their own conformer.
+public protocol DualDynamicHDRStepRunning: Sendable {
+    /// Run a single step. Implementations dispatch on `step.tool`.
+    ///
+    /// - Throws: On failure. The executor treats any thrown error as fatal
+    ///   for the whole pipeline (no partial-success reporting).
+    func run(step: PipelineStepDescriptor) async throws
+}
+
+// MARK: - DualDynamicHDRToolStepRunner
+
+/// The real `DualDynamicHDRStepRunning` implementation used in production.
+///
+/// Every case below delegates to an existing, already-tested runner —
+/// see the file-level overview for the mapping. No ffmpeg/dovi_tool/
+/// hdr10plus_tool invocation logic is reimplemented here.
+public struct DualDynamicHDRToolStepRunner: DualDynamicHDRStepRunning {
+
+    private let doviTool: DoviToolWrapper
+    private let hdr10PlusTool: HDR10PlusToolWrapper
+
+    /// Resolves the ffmpeg binary path for the (HLG-target-only) "ffmpeg"
+    /// step. Defaults to the same `FFmpegBundleManager.locateFFmpeg()`
+    /// lookup used by `QualityMetricsView.runAnalysis()` and
+    /// `VideoTrimmerView.applyTrim()`, run off the calling context via
+    /// `Task.detached` since `locateFFmpeg()` does synchronous filesystem
+    /// probing. Overridable so tests never touch the real filesystem search
+    /// path or spawn a real ffmpeg process.
+    private let ffmpegBinaryPath: @Sendable () async throws -> String
+
+    public init(
+        doviTool: DoviToolWrapper = DoviToolWrapper(),
+        hdr10PlusTool: HDR10PlusToolWrapper = HDR10PlusToolWrapper(),
+        ffmpegBinaryPath: @escaping @Sendable () async throws -> String = {
+            try await Task.detached {
+                try FFmpegBundleManager().locateFFmpeg().path
+            }.value
+        }
+    ) {
+        self.doviTool = doviTool
+        self.hdr10PlusTool = hdr10PlusTool
+        self.ffmpegBinaryPath = ffmpegBinaryPath
+    }
+
+    public func run(step: PipelineStepDescriptor) async throws {
+        switch step.tool {
+        case "dovi_tool":
+            let result = try await doviTool.run(arguments: step.arguments)
+            guard result.exitCode == 0 else {
+                throw DualDynamicHDRPipelineExecutorError.stepFailed(
+                    stepNumber: step.stepNumber,
+                    tool: step.tool,
+                    description: step.description,
+                    underlying: result.stderr.isEmpty ? "dovi_tool exited with code \(result.exitCode)" : result.stderr
+                )
+            }
+
+        case "hdr10plus_tool":
+            let result = try await hdr10PlusTool.run(arguments: step.arguments)
+            guard result.exitCode == 0 else {
+                throw DualDynamicHDRPipelineExecutorError.stepFailed(
+                    stepNumber: step.stepNumber,
+                    tool: step.tool,
+                    description: step.description,
+                    underlying: result.stderr.isEmpty ? "hdr10plus_tool exited with code \(result.exitCode)" : result.stderr
+                )
+            }
+
+        case "internal":
+            // `convertDVMetadataToHDR10Plus` does synchronous file I/O
+            // (Data(contentsOf:) / Data.write(to:)), so it is dispatched via
+            // `Task.detached` — mirroring the codebase's own pattern for
+            // wrapping blocking, non-async work (e.g.
+            // `QualityMetricsView.runAnalysis()`'s `FFmpegBundleManager
+            // .locateFFmpeg()` call) — rather than blocking whatever
+            // executor/thread is driving this async function.
+            try await Task.detached {
+                try DualDynamicHDRPipeline.convertDVMetadataToHDR10Plus(
+                    dvMetadataPath: step.inputPath,
+                    hdr10PlusOutputPath: step.outputPath
+                )
+            }.value
+
+        case "ffmpeg":
+            // Only produced for the five-tier (DV + HDR10+ + HLG) target's
+            // PQ→HLG base-layer conversion step. Uses the same
+            // FFmpegProcessController.startEncoding(arguments:) /
+            // AsyncStream consumption pattern as
+            // `VideoTrimmerView.runToCompletion` — the process's own
+            // completion is awaited by draining its progress stream, not by
+            // any bespoke polling.
+            let binary = try await ffmpegBinaryPath()
+            let controller = FFmpegProcessController(binaryPath: binary)
+            let progressStream = try controller.startEncoding(arguments: step.arguments)
+            for await _ in progressStream {
+                if Task.isCancelled {
+                    controller.stopEncoding()
+                    break
+                }
+            }
+            if Task.isCancelled {
+                throw CancellationError()
+            }
+            if let code = controller.exitCode, code != 0 {
+                throw DualDynamicHDRPipelineExecutorError.stepFailed(
+                    stepNumber: step.stepNumber,
+                    tool: step.tool,
+                    description: step.description,
+                    underlying: controller.errorOutput.isEmpty
+                        ? "ffmpeg exited with code \(code)" : controller.errorOutput
+                )
+            }
+
+        default:
+            throw DualDynamicHDRPipelineExecutorError.unsupportedTool(step.tool)
+        }
+    }
+}
+
+// MARK: - DualDynamicHDRPipelineExecutor
+
+/// Runs an ordered list of `PipelineStepDescriptor`s produced by
+/// `DualDynamicHDRPipeline.buildPipelineSteps(...)`, in order, via an
+/// injected `DualDynamicHDRStepRunning`.
+///
+/// Responsibilities kept deliberately narrow and pure so this class is
+/// fully unit-testable with a mock step runner:
+///   - **Sequencing**: steps run strictly in array order, one at a time.
+///   - **Failure-abort**: the first step to throw stops the pipeline;
+///     no later step runs.
+///   - **Progress**: `onProgress` (if provided) is invoked just before each
+///     step starts, with its 0-based index and the descriptor itself.
+///   - **Cleanup**: every intermediate step output (i.e. every
+///     `step.outputPath` except the final step's) is removed once the
+///     pipeline finishes, whether it finished by succeeding or by throwing.
+///     `step.inputPath` is never touched, so the caller's real source file
+///     is never at risk even if it happens to sit in the same directory.
+///
+/// Concurrency: a plain `final class` holding only a `Sendable` protocol
+/// value — no mutable state — so it is trivially `Sendable` without
+/// `@unchecked`. `execute(steps:onProgress:)` is a non-isolated `async`
+/// method; the `onProgress` callback is a plain `@Sendable` closure (not
+/// `@MainActor`-isolated) and may run on whatever thread the current step's
+/// `await` resumes on — exactly like `EncodingEngine.encode(job:onProgress:)`'s
+/// `@Sendable (FFmpegProgressInfo) -> Void` callback. Callers that need to
+/// touch `@MainActor`-isolated state (SwiftUI `@State`, etc.) from
+/// `onProgress` must hop explicitly, e.g. `Task { @MainActor in ... }`,
+/// exactly as `AppViewModel.startQueue()` does around its own
+/// `progressInfo` callback.
+public final class DualDynamicHDRPipelineExecutor: Sendable {
+
+    private let stepRunner: DualDynamicHDRStepRunning
+
+    /// - Parameter stepRunner: Defaults to `DualDynamicHDRToolStepRunner()`
+    ///   (the real dovi_tool/hdr10plus_tool/ffmpeg dispatcher). Tests inject
+    ///   a mock conforming to `DualDynamicHDRStepRunning` instead.
+    public init(stepRunner: DualDynamicHDRStepRunning = DualDynamicHDRToolStepRunner()) {
+        self.stepRunner = stepRunner
+    }
+
+    /// Execute `steps` in order.
+    ///
+    /// - Parameters:
+    ///   - steps: The ordered pipeline, typically from
+    ///     `DualDynamicHDRPipeline.buildPipelineSteps(...)`. A `nil`/empty
+    ///     array is a no-op success.
+    ///   - onProgress: Invoked immediately before each step runs, with that
+    ///     step's 0-based index and descriptor. Never invoked after the
+    ///     pipeline has finished (successfully or not).
+    /// - Throws: `CancellationError` if the calling `Task` is cancelled
+    ///   between steps; otherwise, whatever the failing step's
+    ///   `DualDynamicHDRStepRunning.run(step:)` threw (real callers see
+    ///   `DualDynamicHDRPipelineExecutorError.stepFailed`, carrying the
+    ///   real tool's own stderr — this executor never fabricates a
+    ///   generic/success result on failure).
+    public func execute(
+        steps: [PipelineStepDescriptor],
+        onProgress: (@Sendable (Int, PipelineStepDescriptor) -> Void)? = nil
+    ) async throws {
+        guard !steps.isEmpty else { return }
+
+        let finalOutputPath = steps.last?.outputPath
+        var producedOutputs: [String] = []
+
+        do {
+            for (index, step) in steps.enumerated() {
+                if Task.isCancelled {
+                    throw CancellationError()
+                }
+                onProgress?(index, step)
+                try await stepRunner.run(step: step)
+                producedOutputs.append(step.outputPath)
+            }
+        } catch {
+            cleanUpIntermediateFiles(producedOutputs, finalOutputPath: finalOutputPath)
+            throw error
+        }
+
+        cleanUpIntermediateFiles(producedOutputs, finalOutputPath: finalOutputPath)
+    }
+
+    /// Removes every produced output except the pipeline's final output.
+    /// Best-effort: a file that does not exist, or cannot be removed, is
+    /// silently skipped — cleanup failures must never mask (or be confused
+    /// with) the pipeline's real success/failure result.
+    private func cleanUpIntermediateFiles(_ paths: [String], finalOutputPath: String?) {
+        for path in paths where path != finalOutputPath {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+}

--- a/Sources/ConverterEngine/Encoding/EncodingStatistics.swift
+++ b/Sources/ConverterEngine/Encoding/EncodingStatistics.swift
@@ -301,6 +301,38 @@ public final class EncodingStatisticsCollector: @unchecked Sendable {
         defer { lock.unlock() }
         return statistics
     }
+
+    // MARK: - FPS Derivation (Issue #284)
+
+    /// Extracts FFmpeg's own `fps=` value from a raw `-progress pipe:1`
+    /// output chunk (`FFmpegProgressInfo.rawLine`).
+    ///
+    /// `FFmpegProcessController.FFmpegProgressInfo` has no `fps` field —
+    /// its `parseProgress(from:)` only extracts `frame`, `speed`,
+    /// `bitrate`, `total_size`, and `out_time`/`out_time_us` from that same
+    /// raw text, even though FFmpeg's `-progress` output includes an `fps=`
+    /// key per progress block (see the sample block in
+    /// `FFmpegProcessController.startEncoding`'s doc comment). This mirrors
+    /// that same `key=value`, one-per-line parsing so a caller wiring up
+    /// `EncodingStatisticsCollector.recordProgress(fps:...)` (which does
+    /// require an `fps` value) can recover it without any change to
+    /// `FFmpegProcessController` itself.
+    ///
+    /// - Parameter rawLine: `FFmpegProgressInfo.rawLine` (or any raw
+    ///   `-progress` output chunk).
+    /// - Returns: The parsed fps value, or `0` if the chunk contains no
+    ///   `fps=` line or its value isn't a valid number (e.g. FFmpeg's own
+    ///   placeholder — it does report `fps=0.00` before the first frame).
+    public static func fps(fromRawProgressLine rawLine: String?) -> Double {
+        guard let rawLine else { return 0 }
+        for line in rawLine.split(separator: "\n") {
+            let parts = line.split(separator: "=", maxSplits: 1)
+            guard parts.count == 2,
+                  parts[0].trimmingCharacters(in: .whitespaces) == "fps" else { continue }
+            return Double(parts[1].trimmingCharacters(in: .whitespaces)) ?? 0
+        }
+        return 0
+    }
 }
 
 // MARK: - EncodingStatisticsStore

--- a/Sources/ConverterEngine/Encoding/EncodingStatistics.swift
+++ b/Sources/ConverterEngine/Encoding/EncodingStatistics.swift
@@ -195,6 +195,67 @@ public struct EncodingStatistics: Codable, Sendable {
             return (point.elapsedSeconds, q)
         }
     }
+
+    // MARK: - CSV Export (Issue #363)
+
+    /// CSV column headers matching `csvRow`'s field order. A single joined
+    /// string (rather than `[String]`) so `EncodingStatisticsStore
+    /// .exportAsCSV()` can prepend it to the row list with no further
+    /// formatting, and so a test can assert on it directly.
+    public static let csvHeader: String = [
+        "job_id", "job_name", "start_time", "end_time", "duration_seconds",
+        "average_fps", "peak_fps", "minimum_fps",
+        "average_bitrate_kbps", "peak_bitrate_kbps", "average_quantizer",
+        "input_file_size_bytes", "output_file_size_bytes",
+        "compression_ratio", "space_savings_percent", "average_speed_factor",
+        "video_codec", "audio_codec", "resolution",
+        "encoding_passes", "data_point_count",
+    ].joined(separator: ",")
+
+    /// A single CSV row summarising this job's statistics, in the same
+    /// column order as `csvHeader`. Reuses the same computed aggregate
+    /// properties (`averageFPS`, `compressionRatio`, etc.) already used to
+    /// drive `EncodingGraphsView`'s stat cards — no new aggregation logic,
+    /// just formatting. Pure string building: no file I/O, cannot throw.
+    public var csvRow: String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+
+        let fields: [String] = [
+            jobID.uuidString,
+            Self.csvEscape(jobName),
+            formatter.string(from: startTime),
+            endTime.map { formatter.string(from: $0) } ?? "",
+            totalEncodingDuration.map { String(format: "%.2f", $0) } ?? "",
+            String(format: "%.2f", averageFPS),
+            String(format: "%.2f", peakFPS),
+            String(format: "%.2f", minimumFPS),
+            averageBitrate.map { String(format: "%.2f", $0) } ?? "",
+            peakBitrate.map { String(format: "%.2f", $0) } ?? "",
+            averageQuantizer.map { String(format: "%.2f", $0) } ?? "",
+            inputFileSize.map { String($0) } ?? "",
+            outputFileSize.map { String($0) } ?? "",
+            compressionRatio.map { String(format: "%.3f", $0) } ?? "",
+            spaceSavingsPercent.map { String(format: "%.2f", $0) } ?? "",
+            averageSpeedFactor.map { String(format: "%.2f", $0) } ?? "",
+            Self.csvEscape(videoCodec ?? ""),
+            Self.csvEscape(audioCodec ?? ""),
+            Self.csvEscape(resolution ?? ""),
+            String(encodingPasses),
+            String(dataPoints.count),
+        ]
+        return fields.joined(separator: ",")
+    }
+
+    /// Escapes a string for safe inclusion in a CSV field (RFC 4180-style):
+    /// wraps the value in double quotes (doubling any internal quotes) when
+    /// it contains a comma, quote, or newline. Left unescaped otherwise.
+    private static func csvEscape(_ value: String) -> String {
+        guard value.contains(",") || value.contains("\"") || value.contains("\n") else {
+            return value
+        }
+        return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
 }
 
 // MARK: - EncodingStatisticsCollector
@@ -389,6 +450,26 @@ public final class EncodingStatisticsStore: @unchecked Sendable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         return try encoder.encode(current)
+    }
+
+    /// Export all statistics as CSV — one row per completed job,
+    /// summarising the same aggregate fields `EncodingGraphsView`'s stat
+    /// cards already display (average/peak FPS, average/peak bitrate,
+    /// compression ratio, space savings, duration). See
+    /// `EncodingStatistics.csvHeader`/`csvRow` (Issue #363) for the pure,
+    /// independently-testable formatting; this method only adds the file
+    /// I/O-adjacent bit (reading `history` under the lock) that
+    /// `exportAsJSON` above also does. Same row order as `exportAsJSON`
+    /// (chronological, oldest first) — never throws, since CSV formatting
+    /// here is pure string building with no encoder that can fail.
+    public func exportAsCSV() -> Data {
+        lock.lock()
+        let current = history
+        lock.unlock()
+
+        var lines = [EncodingStatistics.csvHeader]
+        lines.append(contentsOf: current.map(\.csvRow))
+        return Data(lines.joined(separator: "\n").utf8)
     }
 
     /// Clear all stored statistics.

--- a/Sources/ConverterEngine/Utilities/DoviToolWrapper.swift
+++ b/Sources/ConverterEngine/Utilities/DoviToolWrapper.swift
@@ -382,6 +382,34 @@ public final class DoviToolWrapper: @unchecked Sendable {
         return result.stdout
     }
 
+    // MARK: - Generic Invocation (Issue #370)
+
+    /// Run an arbitrary dovi_tool subcommand and return its raw result.
+    ///
+    /// Exposes the same process runner used by the typed convenience methods
+    /// above (`extractRPU`, `injectRPU`, `convertProfile`, `generateRPU`,
+    /// `info`) for pipeline orchestration callers — such as
+    /// `DualDynamicHDRPipelineExecutor` — that walk a pre-built list of
+    /// `PipelineStepDescriptor`s carrying their own argument arrays,
+    /// including subcommands (e.g. `export`) with no dedicated wrapper
+    /// method yet. Prefer the typed methods when one exists; this is the
+    /// escape hatch for the rest.
+    ///
+    /// - Parameter arguments: Full dovi_tool argument list, e.g.
+    ///   `["export", "-i", rpuBin, "-o", jsonPath]`.
+    /// - Returns: The process exit code and trimmed stdout/stderr.
+    /// - Throws: `DoviToolError.binaryNotFound` if dovi_tool is not
+    ///   installed. Never throws on a non-zero exit code — callers inspect
+    ///   `exitCode` themselves, matching `Process.terminationStatus` semantics.
+    public func run(arguments: [String]) async throws -> (exitCode: Int32, stdout: String, stderr: String) {
+        guard let binary = locateBinary() else {
+            throw DoviToolError.binaryNotFound
+        }
+
+        let result = try await runAsync(binary, arguments: arguments)
+        return (result.exitCode, result.stdout, result.stderr)
+    }
+
     // MARK: - Private Helpers
 
     private struct CommandResult {

--- a/Sources/ConverterEngine/Utilities/HDR10PlusToolWrapper.swift
+++ b/Sources/ConverterEngine/Utilities/HDR10PlusToolWrapper.swift
@@ -275,6 +275,34 @@ public final class HDR10PlusToolWrapper: @unchecked Sendable {
         return ["inject", "-i", inputPath, "-j", metadataPath, "-o", outputPath]
     }
 
+    // MARK: - Generic Invocation (Issue #370)
+
+    /// Run an arbitrary hdr10plus_tool subcommand and return its raw result.
+    ///
+    /// Exposes the same process runner used by the typed convenience methods
+    /// above (`extractMetadata`, `injectMetadata`, `getInfo`,
+    /// `validateMetadata`) for pipeline orchestration callers — such as
+    /// `DualDynamicHDRPipelineExecutor` — that walk a pre-built list of
+    /// `PipelineStepDescriptor`s carrying their own argument arrays. Prefer
+    /// the typed methods when one exists; this is the escape hatch for the
+    /// rest.
+    ///
+    /// - Parameter arguments: Full hdr10plus_tool argument list, e.g.
+    ///   `["inject", "-i", hevcPath, "-j", jsonPath, "-o", outPath]`.
+    /// - Returns: The process exit code and trimmed stdout/stderr.
+    /// - Throws: `HDR10PlusToolError.binaryNotFound` if hdr10plus_tool is
+    ///   not installed. Never throws on a non-zero exit code — callers
+    ///   inspect `exitCode` themselves, matching `Process.terminationStatus`
+    ///   semantics.
+    public func run(arguments: [String]) async throws -> (exitCode: Int32, stdout: String, stderr: String) {
+        guard let binary = locateBinary() else {
+            throw HDR10PlusToolError.binaryNotFound
+        }
+
+        let result = try await runAsync(binary, arguments: arguments)
+        return (result.exitCode, result.stdout, result.stderr)
+    }
+
     // MARK: - Private Helpers
 
     /// Result of a command-line process execution.

--- a/Sources/MeedyaConverter/ViewModels/AppViewModel.swift
+++ b/Sources/MeedyaConverter/ViewModels/AppViewModel.swift
@@ -701,6 +701,24 @@ final class AppViewModel {
                 analytics.track(.profileUsed, properties: ["profile": jobState.config.profile.name])
             }
 
+            // Per-job encoding statistics collector (Issue #284, re #448).
+            // EncodingStatisticsCollector already existed in ConverterEngine
+            // but was referenced nowhere in the pipeline, so
+            // EncodingGraphsView (wired in #448) was always empty. This is
+            // the insertion point: create one collector per job, feed it
+            // from the existing `progressInfo` closure below, and persist
+            // it via `EncodingStatisticsStore` on completion.
+            let statsCollector = EncodingStatisticsCollector(
+                jobID: jobState.config.id,
+                jobName: jobState.config.inputURL.lastPathComponent
+            )
+            statsCollector.setInputMetadata(
+                fileSize: fileSizeInBytes(atPath: jobState.config.inputURL.path),
+                duration: nil,
+                videoCodec: jobState.config.profile.videoCodec?.rawValue,
+                audioCodec: jobState.config.profile.audioCodec?.rawValue
+            )
+
             do {
                 try await engine.encode(job: jobState.config) { progressInfo in
                     Task { @MainActor [weak self] in
@@ -730,6 +748,23 @@ final class AppViewModel {
                                             category: .progress, rawOutput: raw,
                                             jobID: jobState.config.id)
                         }
+
+                        // Record a statistics data point (Issue #284).
+                        // `FFmpegProgressInfo` has no `fps` field, so it is
+                        // recovered from FFmpeg's own raw "fps=" line via
+                        // `EncodingStatisticsCollector.fps(fromRawProgressLine:)`
+                        // rather than changing `FFmpegProcessController`'s
+                        // parser. `recordProgress` self-throttles to its
+                        // configured sample interval, so calling it on
+                        // every tick here is intentional, not wasteful.
+                        statsCollector.recordProgress(
+                            fps: EncodingStatisticsCollector.fps(fromRawProgressLine: progressInfo.rawLine),
+                            bitrate: progressInfo.bitrate,
+                            encodedSeconds: progressInfo.currentTime ?? 0,
+                            frameNumber: progressInfo.frame ?? 0,
+                            outputSizeBytes: progressInfo.totalSize.map { Int64($0) },
+                            speed: progressInfo.speed
+                        )
                     }
                 }
 
@@ -740,6 +775,23 @@ final class AppViewModel {
                 let elapsed = jobState.elapsedTime.map { formatDuration($0) } ?? "unknown"
                 appendLog(.info, "Completed: \(jobState.config.inputURL.lastPathComponent) in \(elapsed)",
                           category: .encoding, jobID: jobState.config.id)
+
+                // Finalise and persist this job's statistics (Issue #284).
+                // `EncodingStatisticsStore` reads/writes its JSON history
+                // file synchronously in `init()`/`addStatistics(_:)`, so —
+                // mirroring `EncodingGraphsView`'s own handling of the same
+                // store — that disk I/O runs via `Task.detached` rather
+                // than blocking this `@MainActor`-isolated method. Only the
+                // `Sendable` `EncodingStatistics` snapshot crosses into the
+                // detached task, never `self`/`jobState`.
+                if let outputSize = fileSizeInBytes(atPath: jobState.config.outputURL.path) {
+                    statsCollector.setOutputFileSize(outputSize)
+                }
+                statsCollector.markComplete()
+                let finalStatistics = statsCollector.currentStatistics
+                await Task.detached {
+                    EncodingStatisticsStore().addStatistics(finalStatistics)
+                }.value
 
                 // Track encode completion with duration category (Issue #183)
                 let durationCategory: String
@@ -893,6 +945,24 @@ final class AppViewModel {
     }
 
     // MARK: - Helpers
+
+    /// The size, in bytes, of the file at `path`, or `nil` if it cannot be
+    /// determined (missing file, unreadable attributes, etc.). Used by the
+    /// queue runner's `EncodingStatisticsCollector` wiring (Issue #284) —
+    /// `nil` is passed straight through rather than fabricating `0`, so an
+    /// unreadable file size stays honestly absent from the stored stats.
+    private func fileSizeInBytes(atPath path: String) -> Int64? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path) else {
+            return nil
+        }
+        if let size = attributes[.size] as? Int64 {
+            return size
+        }
+        if let size = attributes[.size] as? UInt64, size <= UInt64(Int64.max) {
+            return Int64(size)
+        }
+        return nil
+    }
 
     /// Format a time interval as a human-readable duration.
     private func formatDuration(_ interval: TimeInterval) -> String {

--- a/Sources/MeedyaConverter/Views/AnimatedImageView.swift
+++ b/Sources/MeedyaConverter/Views/AnimatedImageView.swift
@@ -6,6 +6,7 @@
 // ============================================================================
 
 import SwiftUI
+import UniformTypeIdentifiers
 import ConverterEngine
 
 // ---------------------------------------------------------------------------
@@ -63,6 +64,16 @@ struct AnimatedImageView: View {
 
     /// Whether a generation operation is currently running.
     @State private var isGenerating: Bool = false
+
+    /// The in-flight generation task, retained so it can be cancelled if
+    /// the user clicks Cancel or navigates away mid-generation. Mirrors
+    /// `VideoTrimmerView.applyTask`.
+    @State private var generationTask: Task<Void, Never>?
+
+    /// The FFmpeg process currently running (palette pass, GIF pass, or the
+    /// single APNG pass), retained so `cancelGeneration()` can stop it.
+    /// Mirrors `VideoTrimmerView.currentController`.
+    @State private var currentController: FFmpegProcessController?
 
     // MARK: - Body
 
@@ -184,19 +195,35 @@ struct AnimatedImageView: View {
                     }
                     .disabled(isGenerating)
                     .keyboardShortcut(.return, modifiers: .command)
+
+                    if isGenerating {
+                        Button("Cancel", action: cancelGeneration)
+                            .accessibilityLabel("Cancel animated image generation")
+                    }
                     Spacer()
                 }
 
                 if let status = statusMessage {
                     Text(status)
                         .font(.caption)
-                        .foregroundStyle(status.contains("Error") ? .red : .green)
+                        .foregroundStyle(statusColor(for: status))
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
             }
         }
         .formStyle(.grouped)
         .navigationTitle("Animated Image")
+        .onDisappear {
+            cancelGeneration()
+        }
+    }
+
+    /// Colour for the status banner: red for a real failure, secondary for
+    /// a user-initiated cancellation, green for success.
+    private func statusColor(for status: String) -> Color {
+        if status.hasPrefix("Error") { return .red }
+        if status == "Cancelled." { return .secondary }
+        return .green
     }
 
     // MARK: - Computed Properties
@@ -245,7 +272,27 @@ struct AnimatedImageView: View {
     // MARK: - Actions
 
     /// Presents an NSSavePanel and generates the animated image.
+    ///
+    /// Real execution (Issue #321): runs the real two-pass GIF-palette /
+    /// single-pass APNG arguments `AnimatedImageGenerator.buildGIFArguments`
+    /// / `buildAPNGArguments` already build, against `viewModel.selectedFile`,
+    /// via `FFmpegProcessController` — the same runner/`AsyncStream`-draining
+    /// pattern `VideoTrimmerView.runSimpleTrim`/`runToCompletion` use. On
+    /// success the real output file exists at the user-chosen path; on
+    /// failure, an honest error naming what actually went wrong (never a
+    /// fabricated "success").
+    ///
+    /// `AnimatedImageView` is a `struct: View`, so the plain `Task { }`
+    /// below inherits main-actor isolation (mirrors `ImageConversionView
+    /// .startConversion()` / `VideoTrimmerView.applyTrim()`): `@State`
+    /// reads/writes are direct property mutations, not `MainActor.run` hops.
     private func generate() {
+        guard !isGenerating else { return }
+        guard let file = viewModel.selectedFile else {
+            statusMessage = "Error: No source file selected. Import a video before generating."
+            return
+        }
+
         let panel = NSSavePanel()
         panel.title = "Save Animated Image"
         panel.nameFieldStringValue = "output.\(format.rawValue)"
@@ -260,23 +307,113 @@ struct AnimatedImageView: View {
         statusMessage = "Generating..."
         isGenerating = true
 
-        // In a real implementation this would invoke FFmpegBackend to
-        // run the generated arguments. For now we store the args to
-        // demonstrate the pipeline integration point.
         let config = currentConfig
-        let _ = format == .gif
-            ? AnimatedImageGenerator.buildGIFArguments(
-                inputPath: "<source>",
-                outputPath: url.path,
-                config: config
-            )
-            : [AnimatedImageGenerator.buildAPNGArguments(
-                inputPath: "<source>",
-                outputPath: url.path,
-                config: config
-            )]
+        let inputPath = file.fileURL.path
+        let outputPath = url.path
 
-        statusMessage = "Arguments prepared for \(url.lastPathComponent)"
+        generationTask = Task {
+            let ffmpegPath: String
+            do {
+                ffmpegPath = try await Task.detached {
+                    try FFmpegBundleManager().locateFFmpeg().path
+                }.value
+            } catch {
+                statusMessage = "Error: FFmpeg could not be found. Install FFmpeg or configure its location in Settings."
+                isGenerating = false
+                return
+            }
+
+            do {
+                switch format {
+                case .gif:
+                    // Two-pass palette workflow: palettegen, then paletteuse.
+                    let passes = AnimatedImageGenerator.buildGIFArguments(
+                        inputPath: inputPath,
+                        outputPath: outputPath,
+                        config: config
+                    )
+
+                    let paletteController = FFmpegProcessController(binaryPath: ffmpegPath)
+                    currentController = paletteController
+                    try await runToCompletion(paletteController, arguments: passes[0])
+
+                    let gifController = FFmpegProcessController(binaryPath: ffmpegPath)
+                    currentController = gifController
+                    try await runToCompletion(gifController, arguments: passes[1])
+
+                    // Remove the intermediate palette PNG
+                    // (AnimatedImageGenerator.buildGIFArguments derives its
+                    // path from the output path's directory).
+                    let paletteDir = (outputPath as NSString).deletingLastPathComponent
+                    let palettePath = (paletteDir as NSString).appendingPathComponent("palette_tmp.png")
+                    try? FileManager.default.removeItem(atPath: palettePath)
+
+                case .apng:
+                    let args = AnimatedImageGenerator.buildAPNGArguments(
+                        inputPath: inputPath,
+                        outputPath: outputPath,
+                        config: config
+                    )
+                    let controller = FFmpegProcessController(binaryPath: ffmpegPath)
+                    currentController = controller
+                    try await runToCompletion(controller, arguments: args)
+                }
+
+                guard FileManager.default.fileExists(atPath: outputPath) else {
+                    throw FFmpegProcessError.processFailure(
+                        exitCode: currentController?.exitCode ?? -1,
+                        stderr: "FFmpeg reported success but no output file was found at \(outputPath)."
+                    )
+                }
+
+                statusMessage = "Generated \(url.lastPathComponent)"
+                viewModel.appendLog(
+                    .info,
+                    "Animated \(format.rawValue.uppercased()) generated: \(url.lastPathComponent)"
+                )
+            } catch is CancellationError {
+                statusMessage = "Cancelled."
+            } catch {
+                statusMessage = "Error: \(error.localizedDescription)"
+                viewModel.appendLog(
+                    .error,
+                    "Animated \(format.rawValue.uppercased()) generation failed: \(error.localizedDescription)"
+                )
+            }
+
+            currentController = nil
+            isGenerating = false
+        }
+    }
+
+    /// Cancel an in-progress generation. Mirrors `VideoTrimmerView.cancelApply()`.
+    private func cancelGeneration() {
+        generationTask?.cancel()
+        currentController?.stopEncoding()
+        currentController = nil
+        generationTask = nil
         isGenerating = false
+    }
+
+    /// Runs an `FFmpegProcessController` encoding pass to completion by
+    /// draining its progress `AsyncStream`. Mirrors
+    /// `VideoTrimmerView.runToCompletion`.
+    private func runToCompletion(
+        _ controller: FFmpegProcessController,
+        arguments: [String]
+    ) async throws {
+        let progressStream = try controller.startEncoding(arguments: arguments)
+        for await _ in progressStream {
+            if Task.isCancelled {
+                controller.stopEncoding()
+                break
+            }
+        }
+        if Task.isCancelled {
+            throw CancellationError()
+        }
+        if let code = controller.exitCode, code != 0 {
+            throw FFmpegProcessError.processFailure(exitCode: code, stderr: controller.errorOutput)
+        }
     }
 }

--- a/Sources/MeedyaConverter/Views/DualDynamicHDRView.swift
+++ b/Sources/MeedyaConverter/Views/DualDynamicHDRView.swift
@@ -6,6 +6,7 @@
 // ============================================================================
 
 import SwiftUI
+import UniformTypeIdentifiers
 import ConverterEngine
 
 // MARK: - DualDynamicHDRView
@@ -56,6 +57,11 @@ struct DualDynamicHDRView: View {
     /// Error message if conversion fails.
     @State private var errorMessage: String?
 
+    /// The in-flight conversion task, retained so it can be cancelled if the
+    /// user navigates away mid-conversion. Mirrors
+    /// `BitrateHeatmapView.analysisTask` / `VideoTrimmerView.applyTask`.
+    @State private var conversionTask: Task<Void, Never>?
+
     /// Whether both required tools are available.
     private var toolsReady: Bool {
         doviToolAvailable && hdr10PlusToolAvailable
@@ -89,6 +95,9 @@ struct DualDynamicHDRView: View {
         .onAppear {
             checkToolAvailability()
             updatePipelinePreview()
+        }
+        .onDisappear {
+            conversionTask?.cancel()
         }
     }
 
@@ -474,16 +483,189 @@ struct DualDynamicHDRView: View {
     }
 
     /// Start the dual dynamic HDR conversion pipeline.
+    ///
+    /// Real execution (Issue #370): extracts a raw HEVC elementary stream
+    /// from the selected source via FFmpeg — the same `-bsf:v
+    /// hevc_mp4toannexb` technique `EncodingEngine.encode(job:onProgress:)`
+    /// already uses for its own DV RPU preservation pass — builds the
+    /// pipeline steps via `DualDynamicHDRPipeline.buildPipelineSteps(...)`
+    /// against that real elementary stream, and runs them with
+    /// `DualDynamicHDRPipelineExecutor`, which dispatches each step to the
+    /// real `DoviToolWrapper` / `HDR10PlusToolWrapper` / (HLG-target-only)
+    /// `FFmpegProcessController` runners. The resulting dual-metadata HEVC
+    /// elementary stream is written to a location the user chooses via
+    /// `NSSavePanel`. Re-muxing it back into a container (mp4/mkv) is a
+    /// separate, larger feature and out of scope here — see the PR
+    /// description for why.
+    ///
+    /// `DualDynamicHDRView` is a `struct: View`, so the plain `Task { }`
+    /// below inherits main-actor isolation (mirrors `ImageConversionView
+    /// .startConversion()` / `VideoTrimmerView.applyTrim()`): `@State`
+    /// reads/writes here are direct property mutations, not `MainActor.run`
+    /// hops. `DualDynamicHDRPipelineExecutor`'s `onProgress` callback is a
+    /// plain `@Sendable` closure (see its doc comment) that may run off the
+    /// main actor, so it re-hops explicitly via `Task { @MainActor in ... }`
+    /// — the same pattern `AppViewModel.startQueue()` uses around
+    /// `engine.encode(job:onProgress:)`'s `progressInfo` callback.
     private func startConversion() {
-        guard toolsReady else { return }
+        guard toolsReady, !isConverting else { return }
+        guard let file = viewModel.selectedFile else {
+            errorMessage = "No source file selected. Import a Dolby Vision file before converting."
+            return
+        }
+
+        let panel = NSSavePanel()
+        panel.title = "Save Dual Dynamic HDR Output"
+        panel.nameFieldStringValue = PathSanitizer.sanitizeFilenameComponent(
+            file.fileURL.deletingPathExtension().lastPathComponent
+        ) + "_dual_hdr.hevc"
+        panel.allowedContentTypes = [UTType(filenameExtension: "hevc") ?? .data]
+
+        guard panel.runModal() == .OK, let outputURL = panel.url else { return }
+
         isConverting = true
         currentStepIndex = 0
         errorMessage = nil
+        statusMessage = "Locating FFmpeg..."
+
+        let sourceProfile = detectedProfile
+        let target = selectedTarget
+        let preserve = preserveDynamicMetadata
+        let inputURL = file.fileURL
+
+        conversionTask = Task {
+            do {
+                try await runDualDynamicHDRConversion(
+                    inputURL: inputURL,
+                    outputURL: outputURL,
+                    sourceProfile: sourceProfile,
+                    target: target,
+                    preserveDynamicMetadata: preserve
+                )
+                statusMessage = "Conversion complete: \(outputURL.lastPathComponent)"
+                viewModel.appendLog(
+                    .info,
+                    "Dual dynamic HDR conversion complete: \(outputURL.lastPathComponent)"
+                )
+            } catch is CancellationError {
+                // Cancelled by the user (or the view disappeared) — no
+                // error banner; the task's own cancellation already
+                // reflects the interruption.
+                statusMessage = "Cancelled."
+            } catch {
+                errorMessage = "Dual dynamic HDR conversion failed: \(error.localizedDescription)"
+                viewModel.appendLog(
+                    .error,
+                    "Dual dynamic HDR conversion failed: \(error.localizedDescription)"
+                )
+            }
+
+            isConverting = false
+        }
+    }
+
+    /// Extracts a raw HEVC elementary stream from `inputURL`, runs the dual
+    /// dynamic HDR pipeline (`DualDynamicHDRPipeline.buildPipelineSteps` +
+    /// `DualDynamicHDRPipelineExecutor`) against it, and writes the
+    /// resulting dual-metadata HEVC stream to `outputURL`. All intermediate
+    /// files live in a scratch temp directory removed before this function
+    /// returns, whether it succeeds or throws.
+    private func runDualDynamicHDRConversion(
+        inputURL: URL,
+        outputURL: URL,
+        sourceProfile: DoviProfile,
+        target: DualHDRTarget,
+        preserveDynamicMetadata: Bool
+    ) async throws {
+        let ffmpegPath = try await Task.detached {
+            try FFmpegBundleManager().locateFFmpeg().path
+        }.value
+
+        let scratchDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dual_hdr_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchDir) }
+
+        // Step 0 (not part of the tool pipeline itself): dovi_tool/
+        // hdr10plus_tool operate on a raw HEVC Annex-B elementary stream,
+        // not an mp4/mkv container, so extract one first — mirroring
+        // EncodingEngine.encode(job:onProgress:)'s own DV RPU preservation
+        // pass (`-c:v copy -bsf:v hevc_mp4toannexb ... -f hevc`).
+        statusMessage = "Extracting elementary stream..."
+        let hevcES = scratchDir.appendingPathComponent("source.hevc")
+        let extractArgs = [
+            "-i", inputURL.path,
+            "-c:v", "copy",
+            "-bsf:v", "hevc_mp4toannexb",
+            "-an", "-sn",
+            "-f", "hevc",
+            "-y", hevcES.path,
+        ]
+        let extractController = FFmpegProcessController(binaryPath: ffmpegPath)
+        try await runToCompletion(extractController, arguments: extractArgs)
+
+        guard FileManager.default.fileExists(atPath: hevcES.path) else {
+            throw FFmpegProcessError.processFailure(
+                exitCode: extractController.exitCode ?? -1,
+                stderr: "FFmpeg produced no elementary stream. Ensure the source uses HEVC video."
+            )
+        }
+
+        let config = DualDynamicHDRConfig(
+            sourceProfile: sourceProfile,
+            target: target,
+            preserveDVDynamicMetadata: preserveDynamicMetadata,
+            tempDirectory: scratchDir
+        )
+        let steps = DualDynamicHDRPipeline.buildPipelineSteps(
+            config: config,
+            inputPath: hevcES.path,
+            outputPath: scratchDir.appendingPathComponent("dual_hdr_output.hevc").path
+        )
+        pipelineSteps = steps
         statusMessage = "Starting pipeline..."
 
-        // Actual execution would be performed by the EncodingEngine.
-        // This view coordinates the UI state; the engine handles process
-        // orchestration and temp file management.
+        let executor = DualDynamicHDRPipelineExecutor()
+        try await executor.execute(steps: steps) { index, step in
+            Task { @MainActor in
+                self.currentStepIndex = index
+                self.statusMessage = "Step \(index + 1)/\(steps.count): \(step.description)"
+            }
+        }
+
+        guard let finalStep = steps.last,
+              FileManager.default.fileExists(atPath: finalStep.outputPath) else {
+            throw DoviToolError.operationFailed("Pipeline reported success but produced no output file.")
+        }
+
+        if FileManager.default.fileExists(atPath: outputURL.path) {
+            try FileManager.default.removeItem(at: outputURL)
+        }
+        try FileManager.default.copyItem(atPath: finalStep.outputPath, toPath: outputURL.path)
+
+        currentStepIndex = steps.count
+    }
+
+    /// Runs an `FFmpegProcessController` encoding pass to completion by
+    /// draining its progress `AsyncStream`. Mirrors
+    /// `VideoTrimmerView.runToCompletion`.
+    private func runToCompletion(
+        _ controller: FFmpegProcessController,
+        arguments: [String]
+    ) async throws {
+        let progressStream = try controller.startEncoding(arguments: arguments)
+        for await _ in progressStream {
+            if Task.isCancelled {
+                controller.stopEncoding()
+                break
+            }
+        }
+        if Task.isCancelled {
+            throw CancellationError()
+        }
+        if let code = controller.exitCode, code != 0 {
+            throw FFmpegProcessError.processFailure(exitCode: code, stderr: controller.errorOutput)
+        }
     }
 
     // MARK: - Fallback Tier Data

--- a/Sources/MeedyaConverter/Views/EncodingGraphsView.swift
+++ b/Sources/MeedyaConverter/Views/EncodingGraphsView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import Charts
+import UniformTypeIdentifiers
 import ConverterEngine
 
 // MARK: - GraphMetric
@@ -68,12 +69,22 @@ struct EncodingGraphsView: View {
     /// seeds its `@State` directly from `CloudProfileSync.shared`.
     @State private var statisticsStore = EncodingStatisticsStore()
 
+    /// Set after a failed CSV export attempt; cleared on the next
+    /// successful export or metric change. Never set on success — a
+    /// successful export closes the save panel with no further UI, mirroring
+    /// `BitrateHeatmapView.exportAsImage()`.
+    @State private var exportErrorMessage: String?
+
     // MARK: - Body
 
     var body: some View {
         VStack(spacing: 0) {
             // Metric selector
             metricPicker
+
+            if let exportErrorMessage {
+                exportErrorBanner(message: exportErrorMessage)
+            }
 
             Divider()
 
@@ -127,6 +138,15 @@ struct EncodingGraphsView: View {
 
             Spacer()
 
+            Button {
+                exportCSV()
+            } label: {
+                Label("Export CSV", systemImage: "square.and.arrow.up")
+            }
+            .disabled(statisticsStore.allStatistics.isEmpty)
+            .help("Export all recorded encoding statistics as CSV")
+            .accessibilityLabel("Export encoding statistics as CSV")
+
             if let stats = currentStatistics {
                 Text(stats.jobName)
                     .font(.headline)
@@ -135,6 +155,24 @@ struct EncodingGraphsView: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 8)
+    }
+
+    /// Inline banner shown after a failed CSV export attempt.
+    private func exportErrorBanner(message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.orange)
+            Spacer()
+            Button("Dismiss") {
+                exportErrorMessage = nil
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.horizontal)
+        .padding(.bottom, 4)
     }
 
     @ViewBuilder
@@ -327,6 +365,32 @@ struct EncodingGraphsView: View {
             return history.first { $0.jobID == selectedJobID }
         }
         return history.first
+    }
+
+    // MARK: - Actions
+
+    /// Exports every recorded job's statistics as CSV via
+    /// `EncodingStatisticsStore.exportAsCSV()` (Issue #363) — one row per
+    /// completed job, not just the currently-displayed one. Pure string
+    /// formatting on the `ConverterEngine` side (see
+    /// `EncodingStatistics.csvHeader`/`csvRow`); this method only adds the
+    /// `NSSavePanel` and the file write, mirroring
+    /// `BitrateHeatmapView.exportAsImage()` / `StatisticsExportView
+    /// .exportData()`'s CSV branch.
+    private func exportCSV() {
+        let panel = NSSavePanel()
+        panel.title = "Export Encoding Statistics"
+        panel.nameFieldStringValue = "encoding_statistics.csv"
+        panel.allowedContentTypes = [UTType.commaSeparatedText]
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            try statisticsStore.exportAsCSV().write(to: url, options: .atomic)
+            exportErrorMessage = nil
+        } catch {
+            exportErrorMessage = "Failed to export CSV: \(error.localizedDescription)"
+        }
     }
 
     private func formatDuration(_ seconds: TimeInterval) -> String {

--- a/Tests/ConverterEngineTests/DualDynamicHDRPipelineExecutorTests.swift
+++ b/Tests/ConverterEngineTests/DualDynamicHDRPipelineExecutorTests.swift
@@ -1,0 +1,291 @@
+// ============================================================================
+// MeedyaConverter — DualDynamicHDRPipelineExecutorTests (Issue #370)
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// MARK: - File Overview
+// ---------------------------------------------------------------------------
+// Pure, CI-runnable tests for `DualDynamicHDRPipelineExecutor` — no real
+// dovi_tool / hdr10plus_tool / ffmpeg binary is ever invoked. A
+// `MockDualDynamicHDRStepRunner` (conforming to the public
+// `DualDynamicHDRStepRunning` protocol) is injected in place of the real
+// `DualDynamicHDRToolStepRunner`, so sequencing, failure-abort, progress
+// reporting, and temp-file cleanup can all be exercised deterministically.
+//
+// `DualDynamicHDRToolStepRunner`'s own dispatch-on-`step.tool` logic is
+// covered too, but only for the `default` (unsupported tool) branch, which
+// never touches a real binary.
+//
+// Only public API is exercised (`import ConverterEngine`, no `@testable`),
+// matching the policy documented at the top of `ConverterEngineTests.swift`.
+// ---------------------------------------------------------------------------
+
+import XCTest
+import ConverterEngine
+
+// MARK: - MockDualDynamicHDRStepRunner
+
+/// Records the order `run(step:)` was called in, optionally throws when a
+/// configured step number runs, and optionally materialises `step.outputPath`
+/// as an empty file so the executor's cleanup logic has something real to
+/// remove — simulating what a real tool run would have left behind.
+final class MockDualDynamicHDRStepRunner: DualDynamicHDRStepRunning, @unchecked Sendable {
+    struct SimulatedFailure: Error, Equatable {
+        let stepNumber: Int
+    }
+
+    private let lock = NSLock()
+    private var recordedSteps: [Int] = []
+
+    /// If set, `run(step:)` throws `SimulatedFailure` when this step number
+    /// is reached, after recording it (but before creating its output file).
+    var failAtStepNumber: Int?
+
+    /// Whether `run(step:)` should create an (empty) file at
+    /// `step.outputPath`, simulating a real tool producing its declared
+    /// output. Defaults to `true`.
+    var createsOutputFiles: Bool = true
+
+    /// Step numbers `run(step:)` was called for, in call order.
+    var ranSteps: [Int] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedSteps
+    }
+
+    func run(step: PipelineStepDescriptor) async throws {
+        lock.lock()
+        recordedSteps.append(step.stepNumber)
+        lock.unlock()
+
+        if step.stepNumber == failAtStepNumber {
+            throw SimulatedFailure(stepNumber: step.stepNumber)
+        }
+
+        if createsOutputFiles {
+            FileManager.default.createFile(
+                atPath: step.outputPath,
+                contents: Data("step-\(step.stepNumber)-output".utf8)
+            )
+        }
+    }
+}
+
+// MARK: - ProgressRecorder
+
+/// Records `onProgress` callback invocations under a lock. The executor's
+/// `onProgress` parameter is a plain (non-async) `@Sendable` closure — see
+/// `DualDynamicHDRPipelineExecutor`'s doc comment — so tests need a
+/// synchronous, thread-safe sink rather than an `actor` (which would force
+/// the closure to hop via a detached `Task`, breaking the ordering this
+/// test asserts on). Mirrors the lock-protected recorder pattern in
+/// `CloudUploadExecutorTests.MockURLProtocol`.
+final class ProgressRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedCalls: [(index: Int, stepNumber: Int)] = []
+
+    var calls: [(index: Int, stepNumber: Int)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedCalls
+    }
+
+    func record(index: Int, stepNumber: Int) {
+        lock.lock()
+        recordedCalls.append((index, stepNumber))
+        lock.unlock()
+    }
+}
+
+// MARK: - DualDynamicHDRPipelineExecutorTests
+
+final class DualDynamicHDRPipelineExecutorTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dual-hdr-executor-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        super.tearDown()
+    }
+
+    /// Builds `count` steps with real, distinct file paths under `tempDir`,
+    /// numbered 1...count.
+    private func makeSteps(count: Int, tool: String = "dovi_tool") -> [PipelineStepDescriptor] {
+        (1...count).map { n in
+            PipelineStepDescriptor(
+                stepNumber: n,
+                tool: tool,
+                description: "Step \(n)",
+                arguments: ["noop-\(n)"],
+                inputPath: tempDir.appendingPathComponent("in\(n).bin").path,
+                outputPath: tempDir.appendingPathComponent("out\(n).bin").path
+            )
+        }
+    }
+
+    // MARK: - Sequencing
+
+    func test_execute_runsAllStepsInOrder() async throws {
+        let steps = makeSteps(count: 4)
+        let mock = MockDualDynamicHDRStepRunner()
+        let executor = DualDynamicHDRPipelineExecutor(stepRunner: mock)
+
+        try await executor.execute(steps: steps)
+
+        XCTAssertEqual(mock.ranSteps, [1, 2, 3, 4])
+    }
+
+    func test_execute_emptySteps_isNoOpSuccess() async throws {
+        let mock = MockDualDynamicHDRStepRunner()
+        let executor = DualDynamicHDRPipelineExecutor(stepRunner: mock)
+
+        try await executor.execute(steps: [])
+
+        XCTAssertEqual(mock.ranSteps, [])
+    }
+
+    func test_execute_reportsProgressForEachStepBeforeItRuns() async throws {
+        let steps = makeSteps(count: 3)
+        let mock = MockDualDynamicHDRStepRunner()
+        let executor = DualDynamicHDRPipelineExecutor(stepRunner: mock)
+        let recorder = ProgressRecorder()
+
+        try await executor.execute(steps: steps) { index, step in
+            recorder.record(index: index, stepNumber: step.stepNumber)
+        }
+
+        XCTAssertEqual(recorder.calls.map(\.index), [0, 1, 2])
+        XCTAssertEqual(recorder.calls.map(\.stepNumber), [1, 2, 3])
+    }
+
+    // MARK: - Failure Abort
+
+    func test_execute_abortsOnFirstFailure_laterStepsNeverRun() async throws {
+        let steps = makeSteps(count: 5)
+        let mock = MockDualDynamicHDRStepRunner()
+        mock.failAtStepNumber = 3
+        let executor = DualDynamicHDRPipelineExecutor(stepRunner: mock)
+
+        do {
+            try await executor.execute(steps: steps)
+            XCTFail("Expected the executor to throw when step 3 fails")
+        } catch let error as MockDualDynamicHDRStepRunner.SimulatedFailure {
+            XCTAssertEqual(error.stepNumber, 3)
+        }
+
+        // Steps 1 and 2 ran; step 3 ran (and threw); steps 4 and 5 never ran.
+        XCTAssertEqual(mock.ranSteps, [1, 2, 3])
+    }
+
+    func test_execute_neverFabricatesSuccessAfterFailure() async throws {
+        let steps = makeSteps(count: 2)
+        let mock = MockDualDynamicHDRStepRunner()
+        mock.failAtStepNumber = 1
+        let executor = DualDynamicHDRPipelineExecutor(stepRunner: mock)
+
+        var threw = false
+        do {
+            try await executor.execute(steps: steps)
+        } catch {
+            threw = true
+        }
+        XCTAssertTrue(threw, "A failing first step must propagate as a thrown error, never a silent success")
+    }
+
+    // MARK: - Cleanup
+
+    func test_execute_onSuccess_removesIntermediateOutputs_keepsFinalOutput() async throws {
+        let steps = makeSteps(count: 3)
+        let mock = MockDualDynamicHDRStepRunner()
+        let executor = DualDynamicHDRPipelineExecutor(stepRunner: mock)
+
+        try await executor.execute(steps: steps)
+
+        // Steps 1 and 2's outputs are intermediate — removed after success.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: steps[0].outputPath))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: steps[1].outputPath))
+        // Step 3's output is the pipeline's final result — preserved.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: steps[2].outputPath))
+    }
+
+    func test_execute_onFailure_removesFilesProducedBeforeTheFailingStep() async throws {
+        let steps = makeSteps(count: 4)
+        let mock = MockDualDynamicHDRStepRunner()
+        mock.failAtStepNumber = 3
+        let executor = DualDynamicHDRPipelineExecutor(stepRunner: mock)
+
+        do {
+            try await executor.execute(steps: steps)
+            XCTFail("Expected failure")
+        } catch {
+            // expected
+        }
+
+        // Steps 1 and 2 produced real files before the failure — cleaned up.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: steps[0].outputPath))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: steps[1].outputPath))
+        // Step 3 threw before creating its output file in this mock.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: steps[2].outputPath))
+        // Step 4 never ran.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: steps[3].outputPath))
+    }
+
+    func test_execute_neverRemoves_stepInputPaths() async throws {
+        // A source file that happens to live in the same temp directory as
+        // the pipeline's intermediate outputs must never be touched by
+        // cleanup — only `step.outputPath`s are ever candidates for removal.
+        let sourcePath = tempDir.appendingPathComponent("real_source.hevc").path
+        FileManager.default.createFile(atPath: sourcePath, contents: Data("source".utf8))
+
+        let steps = [
+            PipelineStepDescriptor(
+                stepNumber: 1,
+                tool: "dovi_tool",
+                description: "Extract",
+                arguments: ["extract-rpu", "-i", sourcePath, "-o", tempDir.appendingPathComponent("rpu.bin").path],
+                inputPath: sourcePath,
+                outputPath: tempDir.appendingPathComponent("rpu.bin").path
+            ),
+        ]
+        let mock = MockDualDynamicHDRStepRunner()
+        let executor = DualDynamicHDRPipelineExecutor(stepRunner: mock)
+
+        try await executor.execute(steps: steps)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sourcePath), "The real source file must never be deleted by cleanup")
+    }
+
+    // MARK: - DualDynamicHDRToolStepRunner (real dispatcher, unsupported-tool branch only)
+
+    func test_toolStepRunner_unsupportedTool_throwsWithoutTouchingAnyRealBinary() async throws {
+        let runner = DualDynamicHDRToolStepRunner()
+        let step = PipelineStepDescriptor(
+            stepNumber: 1,
+            tool: "not_a_real_tool",
+            description: "Bogus step",
+            arguments: [],
+            inputPath: "/dev/null",
+            outputPath: tempDir.appendingPathComponent("out.bin").path
+        )
+
+        do {
+            try await runner.run(step: step)
+            XCTFail("Expected unsupportedTool to be thrown")
+        } catch let error as DualDynamicHDRPipelineExecutorError {
+            XCTAssertEqual(error, .unsupportedTool("not_a_real_tool"))
+        }
+    }
+}

--- a/Tests/ConverterEngineTests/DualDynamicHDRPipelineExecutorTests.swift
+++ b/Tests/ConverterEngineTests/DualDynamicHDRPipelineExecutorTests.swift
@@ -57,9 +57,12 @@ final class MockDualDynamicHDRStepRunner: DualDynamicHDRStepRunning, @unchecked 
     }
 
     func run(step: PipelineStepDescriptor) async throws {
-        lock.lock()
-        recordedSteps.append(step.stepNumber)
-        lock.unlock()
+        // Use withLock so the lock/unlock pair is async-safe — bare
+        // `NSLock.lock()` / `.unlock()` calls are unavailable from
+        // async contexts under Swift 6 strict concurrency.
+        lock.withLock {
+            recordedSteps.append(step.stepNumber)
+        }
 
         if step.stepNumber == failAtStepNumber {
             throw SimulatedFailure(stepNumber: step.stepNumber)

--- a/Tests/ConverterEngineTests/EncodingStatisticsCSVExportTests.swift
+++ b/Tests/ConverterEngineTests/EncodingStatisticsCSVExportTests.swift
@@ -1,0 +1,199 @@
+// ============================================================================
+// MeedyaConverter — EncodingStatisticsCSVExportTests (Issue #363)
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// MARK: - File Overview
+// ---------------------------------------------------------------------------
+// Pure, CI-runnable tests for `EncodingStatistics.csvHeader`/`csvRow` and
+// `EncodingStatisticsStore.exportAsCSV()` — string formatting only, no file
+// I/O beyond the store's own (already-tested, see
+// `EncodingStatisticsStoreTests`) JSON persistence.
+//
+// Only public API is exercised (`import ConverterEngine`, no `@testable`),
+// matching the policy documented at the top of `ConverterEngineTests.swift`.
+// ---------------------------------------------------------------------------
+
+import XCTest
+import ConverterEngine
+
+final class EncodingStatisticsCSVExportTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Splits a CSV row into fields on unquoted commas, respecting
+    /// RFC 4180 double-quoted fields — including a doubled `""` inside a
+    /// quoted field, which represents one literal `"` character rather
+    /// than closing-then-reopening the quoted section. Good enough for
+    /// asserting on `csvRow`'s own output in these tests without depending
+    /// on a third-party CSV parser.
+    private func splitCSVRow(_ row: String) -> [String] {
+        var fields: [String] = []
+        var current = ""
+        var insideQuotes = false
+        let chars = Array(row)
+        var i = 0
+        while i < chars.count {
+            let char = chars[i]
+            if char == "\"" {
+                if insideQuotes, i + 1 < chars.count, chars[i + 1] == "\"" {
+                    current.append("\"")
+                    i += 2
+                    continue
+                }
+                insideQuotes.toggle()
+                i += 1
+                continue
+            }
+            if char == "," && !insideQuotes {
+                fields.append(current)
+                current = ""
+                i += 1
+                continue
+            }
+            current.append(char)
+            i += 1
+        }
+        fields.append(current)
+        return fields
+    }
+
+    // MARK: - csvHeader
+
+    func test_csvHeader_columnCount_matchesRowFieldCount() {
+        let headerColumns = EncodingStatistics.csvHeader.split(separator: ",")
+
+        var stats = EncodingStatistics(jobID: UUID(), jobName: "sample.mov")
+        stats.addDataPoint(EncodingDataPoint(elapsedSeconds: 1, encodedSeconds: 1, fps: 30, frameNumber: 1))
+        let rowFields = splitCSVRow(stats.csvRow)
+
+        XCTAssertEqual(headerColumns.count, rowFields.count)
+    }
+
+    func test_csvHeader_startsWithJobIdAndJobName() {
+        XCTAssertTrue(EncodingStatistics.csvHeader.hasPrefix("job_id,job_name,"))
+    }
+
+    // MARK: - csvRow — populated fields
+
+    func test_csvRow_populatedJob_containsRealAggregateValues() throws {
+        let jobID = UUID()
+        var stats = EncodingStatistics(jobID: jobID, jobName: "movie.mkv")
+        stats.addDataPoint(EncodingDataPoint(elapsedSeconds: 1, encodedSeconds: 1, fps: 20, bitrate: 4_000, frameNumber: 20))
+        stats.addDataPoint(EncodingDataPoint(elapsedSeconds: 2, encodedSeconds: 2, fps: 30, bitrate: 6_000, frameNumber: 50))
+        stats.inputFileSize = 2_000_000
+        stats.outputFileSize = 500_000
+        stats.videoCodec = "h265"
+        stats.audioCodec = "aac"
+        stats.endTime = stats.startTime.addingTimeInterval(120)
+
+        let fields = splitCSVRow(stats.csvRow)
+        let header = EncodingStatistics.csvHeader.split(separator: ",").map(String.init)
+
+        func value(_ column: String) throws -> String {
+            let index = try XCTUnwrap(header.firstIndex(of: column))
+            return fields[index]
+        }
+
+        XCTAssertEqual(try value("job_id"), jobID.uuidString)
+        XCTAssertEqual(try value("job_name"), "movie.mkv")
+        XCTAssertEqual(try value("average_fps"), "25.00")
+        XCTAssertEqual(try value("peak_fps"), "30.00")
+        XCTAssertEqual(try value("minimum_fps"), "20.00")
+        XCTAssertEqual(try value("average_bitrate_kbps"), "5000.00")
+        XCTAssertEqual(try value("peak_bitrate_kbps"), "6000.00")
+        XCTAssertEqual(try value("input_file_size_bytes"), "2000000")
+        XCTAssertEqual(try value("output_file_size_bytes"), "500000")
+        XCTAssertEqual(try value("compression_ratio"), "4.000")
+        XCTAssertEqual(try value("space_savings_percent"), "75.00")
+        XCTAssertEqual(try value("video_codec"), "h265")
+        XCTAssertEqual(try value("audio_codec"), "aac")
+        XCTAssertEqual(try value("data_point_count"), "2")
+        XCTAssertEqual(try value("duration_seconds"), "120.00")
+    }
+
+    // MARK: - csvRow — never fabricates missing data
+
+    func test_csvRow_jobWithNoDataPointsOrFileSizes_leavesOptionalFieldsEmptyRatherThanFabricated() throws {
+        let stats = EncodingStatistics(jobID: UUID(), jobName: "empty.mov")
+
+        let fields = splitCSVRow(stats.csvRow)
+        let header = EncodingStatistics.csvHeader.split(separator: ",").map(String.init)
+
+        func value(_ column: String) throws -> String {
+            let index = try XCTUnwrap(header.firstIndex(of: column))
+            return fields[index]
+        }
+
+        // Never-recorded optional metrics are empty fields, not "0" or "N/A".
+        XCTAssertEqual(try value("input_file_size_bytes"), "")
+        XCTAssertEqual(try value("output_file_size_bytes"), "")
+        XCTAssertEqual(try value("compression_ratio"), "")
+        XCTAssertEqual(try value("space_savings_percent"), "")
+        XCTAssertEqual(try value("average_bitrate_kbps"), "")
+        XCTAssertEqual(try value("video_codec"), "")
+        XCTAssertEqual(try value("end_time"), "")
+        // FPS aggregates are legitimately 0 (defined that way by
+        // EncodingStatistics.averageFPS/peakFPS/minimumFPS) when there are
+        // no data points — that is the real value, not a placeholder.
+        XCTAssertEqual(try value("average_fps"), "0.00")
+        XCTAssertEqual(try value("data_point_count"), "0")
+    }
+
+    // MARK: - csvRow — escaping
+
+    func test_csvRow_jobNameContainingCommaAndQuote_isEscapedAndRoundTrips() {
+        let stats = EncodingStatistics(jobID: UUID(), jobName: "My \"Movie\", Part 1.mov")
+
+        let fields = splitCSVRow(stats.csvRow)
+        let header = EncodingStatistics.csvHeader.split(separator: ",").map(String.init)
+        let jobNameIndex = header.firstIndex(of: "job_name")!
+
+        // The raw row must quote the field (comma/quote present)...
+        XCTAssertTrue(stats.csvRow.contains("\"My \"\"Movie\"\", Part 1.mov\""))
+        // ...and a naive splitter that understands quoting recovers the
+        // original, unescaped value.
+        XCTAssertEqual(fields[jobNameIndex], "My \"Movie\", Part 1.mov")
+    }
+
+    func test_csvRow_plainJobName_isNotQuoted() {
+        let stats = EncodingStatistics(jobID: UUID(), jobName: "plain_name.mov")
+        XCTAssertFalse(stats.csvRow.contains("\"plain_name.mov\""))
+        XCTAssertTrue(stats.csvRow.contains("plain_name.mov"))
+    }
+
+    // MARK: - EncodingStatisticsStore.exportAsCSV()
+
+    func test_store_exportAsCSV_emptyHistory_isJustTheHeader() {
+        let store = EncodingStatisticsStore(
+            directory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("csv-export-tests-\(UUID().uuidString)")
+        )
+
+        let csv = store.exportAsCSV()
+        let text = String(data: csv, encoding: .utf8)
+
+        XCTAssertEqual(text, EncodingStatistics.csvHeader)
+    }
+
+    func test_store_exportAsCSV_withHistory_headerPlusOneRowPerJob() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("csv-export-tests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let store = EncodingStatisticsStore(directory: tempDir)
+        store.addStatistics(EncodingStatistics(jobID: UUID(), jobName: "first.mov"))
+        store.addStatistics(EncodingStatistics(jobID: UUID(), jobName: "second.mov"))
+
+        let csv = try XCTUnwrap(String(data: store.exportAsCSV(), encoding: .utf8))
+        let lines = csv.split(separator: "\n", omittingEmptySubsequences: false)
+
+        XCTAssertEqual(lines.count, 3) // header + 2 job rows
+        XCTAssertEqual(String(lines[0]), EncodingStatistics.csvHeader)
+        XCTAssertTrue(lines[1].contains("first.mov"))
+        XCTAssertTrue(lines[2].contains("second.mov"))
+    }
+}

--- a/Tests/ConverterEngineTests/EncodingStatisticsStoreTests.swift
+++ b/Tests/ConverterEngineTests/EncodingStatisticsStoreTests.swift
@@ -1,0 +1,203 @@
+// ============================================================================
+// MeedyaConverter — EncodingStatisticsStoreTests (Issue #284)
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// MARK: - File Overview
+// ---------------------------------------------------------------------------
+// `EncodingStatisticsCollector`/`EncodingStatisticsStore` existed in
+// ConverterEngine but were referenced nowhere in the encode pipeline, so
+// `EncodingGraphsView` (wired in #448) was always empty. `AppViewModel
+// .startQueue()` now creates a collector per job, feeds it from the
+// existing `progressInfo` closure, and persists it via
+// `EncodingStatisticsStore.addStatistics(_:)` on completion — a view-model
+// change that can't itself be exercised from this test target (SPM test
+// targets cannot import the `MeedyaConverter` executable target — see the
+// note above `MeedyaConvertTests` in Package.swift). What *is* fully
+// CI-testable, and covered below, is the real persistence layer that
+// wiring depends on:
+//   - `EncodingStatisticsStore` round-trips a completed job's statistics
+//     through disk (a fresh store instance, backed by the same directory,
+//     must read back what an earlier instance wrote).
+//   - `EncodingStatisticsCollector.recordProgress`/`setOutputFileSize`/
+//     `markComplete` populate the fields `AppViewModel.startQueue()` relies
+//     on before handing the snapshot to the store.
+//   - `EncodingStatisticsCollector.fps(fromRawProgressLine:)`, the small
+//     pure helper added so the view-model wiring can recover FFmpeg's own
+//     `fps=` value from `FFmpegProgressInfo.rawLine` without changing
+//     `FFmpegProcessController`'s parser.
+//
+// Only public API is exercised (`import ConverterEngine`, no `@testable`),
+// matching the policy documented at the top of `ConverterEngineTests.swift`.
+// ---------------------------------------------------------------------------
+
+import XCTest
+import ConverterEngine
+
+final class EncodingStatisticsStoreTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("encoding-statistics-store-tests-\(UUID().uuidString)")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        super.tearDown()
+    }
+
+    // MARK: - Store Round Trip
+
+    func test_addStatistics_roundTripsThroughANewStoreInstanceBackedByTheSameDirectory() throws {
+        let jobID = UUID()
+        var stats = EncodingStatistics(jobID: jobID, jobName: "sample.mov")
+        stats.addDataPoint(EncodingDataPoint(
+            elapsedSeconds: 1,
+            encodedSeconds: 1,
+            fps: 30,
+            bitrate: 5000,
+            frameNumber: 30
+        ))
+        stats.inputFileSize = 1_000_000
+        stats.outputFileSize = 400_000
+        stats.endTime = Date()
+
+        let writer = EncodingStatisticsStore(directory: tempDir)
+        writer.addStatistics(stats)
+
+        // A brand-new instance, backed by the same directory, must read the
+        // persisted history back from disk in its own `init()` — this is
+        // exactly what `EncodingGraphsView.onAppear` relies on to see a job
+        // completed by a separately-constructed store instance.
+        let reader = EncodingStatisticsStore(directory: tempDir)
+        let loaded = try XCTUnwrap(reader.statistics(forJob: jobID))
+
+        XCTAssertEqual(loaded.jobID, jobID)
+        XCTAssertEqual(loaded.jobName, "sample.mov")
+        XCTAssertEqual(loaded.dataPoints.count, 1)
+        XCTAssertEqual(loaded.dataPoints.first?.fps, 30)
+        XCTAssertEqual(loaded.inputFileSize, 1_000_000)
+        XCTAssertEqual(loaded.outputFileSize, 400_000)
+        XCTAssertNotNil(loaded.endTime)
+    }
+
+    func test_allStatistics_returnsNewestFirst() {
+        let store = EncodingStatisticsStore(directory: tempDir)
+        let older = EncodingStatistics(jobID: UUID(), jobName: "older", startTime: Date(timeIntervalSince1970: 0))
+        let newer = EncodingStatistics(jobID: UUID(), jobName: "newer", startTime: Date(timeIntervalSince1970: 1_000))
+
+        store.addStatistics(older)
+        store.addStatistics(newer)
+
+        XCTAssertEqual(store.allStatistics.map(\.jobName), ["newer", "older"])
+    }
+
+    func test_clearHistory_removesEverythingIncludingFromANewInstance() {
+        let store = EncodingStatisticsStore(directory: tempDir)
+        store.addStatistics(EncodingStatistics(jobID: UUID(), jobName: "to-be-cleared"))
+        XCTAssertFalse(store.allStatistics.isEmpty)
+
+        store.clearHistory()
+        XCTAssertTrue(store.allStatistics.isEmpty)
+
+        let reader = EncodingStatisticsStore(directory: tempDir)
+        XCTAssertTrue(reader.allStatistics.isEmpty)
+    }
+
+    // MARK: - EncodingStatisticsCollector
+
+    func test_collector_recordProgressAndMarkComplete_populateTheFieldsTheQueueRunnerRelisOn() {
+        let jobID = UUID()
+        let collector = EncodingStatisticsCollector(jobID: jobID, jobName: "collector.mov")
+        collector.setInputMetadata(
+            fileSize: 2_000_000,
+            duration: 60,
+            videoCodec: "h265",
+            audioCodec: "aac"
+        )
+
+        collector.recordProgress(
+            fps: 24,
+            bitrate: 6_000,
+            encodedSeconds: 10,
+            frameNumber: 240,
+            outputSizeBytes: 500_000,
+            speed: 1.5
+        )
+        collector.setOutputFileSize(900_000)
+        collector.markComplete()
+
+        let stats = collector.currentStatistics
+        XCTAssertEqual(stats.jobID, jobID)
+        XCTAssertEqual(stats.dataPoints.count, 1)
+        XCTAssertEqual(stats.dataPoints.first?.fps, 24)
+        XCTAssertEqual(stats.dataPoints.first?.frameNumber, 240)
+        XCTAssertEqual(stats.inputFileSize, 2_000_000)
+        XCTAssertEqual(stats.inputDuration, 60)
+        XCTAssertEqual(stats.videoCodec, "h265")
+        XCTAssertEqual(stats.audioCodec, "aac")
+        XCTAssertEqual(stats.outputFileSize, 900_000)
+        XCTAssertNotNil(stats.endTime)
+    }
+
+    func test_collector_recordProgress_throttlesToSampleInterval() {
+        let collector = EncodingStatisticsCollector(
+            jobID: UUID(),
+            jobName: "throttle.mov",
+            sampleInterval: 3_600 // effectively never re-samples within this test
+        )
+
+        collector.recordProgress(fps: 10, encodedSeconds: 1, frameNumber: 1)
+        collector.recordProgress(fps: 20, encodedSeconds: 2, frameNumber: 2)
+        collector.recordProgress(fps: 30, encodedSeconds: 3, frameNumber: 3)
+
+        // Only the first call lands — the others are within the sample
+        // interval of the first and are dropped, exactly as
+        // `AppViewModel.startQueue()` relies on when it calls
+        // `recordProgress` on every FFmpeg progress tick.
+        XCTAssertEqual(collector.currentStatistics.dataPoints.count, 1)
+        XCTAssertEqual(collector.currentStatistics.dataPoints.first?.fps, 10)
+    }
+
+    // MARK: - EncodingStatisticsCollector.fps(fromRawProgressLine:)
+
+    func test_fpsFromRawProgressLine_parsesARealFFmpegProgressChunk() {
+        let raw = """
+        frame=120
+        fps=29.97
+        bitrate=5000.0kbits/s
+        total_size=12345678
+        out_time_us=4000000
+        speed=2.5x
+        progress=continue
+        """
+        XCTAssertEqual(EncodingStatisticsCollector.fps(fromRawProgressLine: raw), 29.97, accuracy: 0.0001)
+    }
+
+    func test_fpsFromRawProgressLine_missingKey_returnsZero() {
+        XCTAssertEqual(
+            EncodingStatisticsCollector.fps(fromRawProgressLine: "frame=1\nbitrate=100.0kbits/s\n"),
+            0
+        )
+    }
+
+    func test_fpsFromRawProgressLine_nilInput_returnsZero() {
+        XCTAssertEqual(EncodingStatisticsCollector.fps(fromRawProgressLine: nil), 0)
+    }
+
+    func test_fpsFromRawProgressLine_malformedValue_returnsZeroRatherThanCrashing() {
+        XCTAssertEqual(
+            EncodingStatisticsCollector.fps(fromRawProgressLine: "fps=not-a-number\n"),
+            0
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Bundle 3 (#448 remainder) — makes four **closed-in-error** features actually execute instead of building args/UI-state and stopping.

## Changes Made

- [x] **3a DualDynamicHDR execution (Closes #370)** — new `DualDynamicHDRPipelineExecutor` dispatches each pipeline step via the existing real runners (`dovi_tool`/`hdr10plus_tool` via thin public passthroughs onto their `runAsync`, `convertDVMetadataToHDR10Plus`, `FFmpegProcessController`); `startConversion()` extracts the HEVC stream + runs it with progress + save panel. Mock-step-runner tests.
- [x] **3b Stats collector wired (Closes #284)** — `AppViewModel.startQueue()` creates an `EncodingStatisticsCollector` per job, records progress in the existing closure, persists on success via `EncodingStatisticsStore` (off-main). fps parsed from ffmpeg's `fps=` key. So `EncodingGraphsView` now fills after a real encode. Store round-trip test.
- [x] **3c CSV export (Closes #363)** — `EncodingStatistics.csvHeader/csvRow` + `EncodingStatisticsStore.exportAsCSV()` + button; RFC4180-escaped; tested.
- [x] **3d AnimatedImage execution (Closes #321)** — `generate()` runs the real two-pass GIF-palette / APNG workflow via `FFmpegProcessController` + cancel.

## ⚠️ Finding (flagging — separate follow-up)

There's a **second, pre-existing** statistics surface — `StatisticsExportView`/`StatisticsExporter`/`EncodeHistoryEntry`, plus `DashboardView` and `StatisticsTracker` — wired to placeholder/empty data, with `recordEncode` never called and no per-job history store, and `StatisticsExportView` isn't reachable from navigation. Fixing it honestly needs a new persistent store. Not addressed here; recommend a dedicated issue.

## Testing Done

CI is the gate (macOS-only) incl. **security checks**. Pure logic (executor sequencing, CSV, fps parse, store round-trip) is unit-tested; UI wiring in the app target can't be unit-tested (no test target imports it). Watch: `UTType`/`NSSavePanel` imports, `Task`/`@MainActor` isolation in the new View wiring.

## Related Issues

Closes #370, #284, #363, #321; addresses #448.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NF44GLcMisedfvxHzhscJQ)_