### PR TITLE
AWS SigV4 signer + real S3 upload (#459)

### DIFF
--- a/Sources/ConverterEngine/Cloud/AWSV4Signer.swift
+++ b/Sources/ConverterEngine/Cloud/AWSV4Signer.swift
@@ -1,0 +1,548 @@
+// ============================================================================
+// MeedyaConverter — AWSV4Signer (Issue #459, Bundle 1b)
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+
+import Foundation
+#if canImport(CommonCrypto)
+import CommonCrypto
+#endif
+
+// ---------------------------------------------------------------------------
+// MARK: - File Overview
+// ---------------------------------------------------------------------------
+// A from-the-spec implementation of AWS Signature Version 4 (SigV4) request
+// signing — https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
+//
+// Every function here is a PURE function of its arguments:
+//   - No singleton state, no `@unchecked Sendable`, no mutable class
+//     instances (the closest thing to shared state, `Calendar`/`Date`
+//     formatting, is done with value-type `Calendar` built fresh per
+//     call — never a cached `DateFormatter`, which is not guaranteed
+//     thread-safe for concurrent formatting).
+//   - `sign(...)` NEVER calls `Date()` itself — the caller always
+//     supplies `date`. Production callers (`S3Uploader`) pass `Date()`
+//     at their own call site; `AWSV4SignerTests` passes AWS's fixed
+//     documented timestamps so every output is byte-for-byte
+//     reproducible against AWS's own published vectors.
+//
+// Correctness verification (this file's whole reason for existing is
+// security-sensitive cryptographic signing, so "trust me" is not
+// enough): `AWSV4SignerTests` reproduces four independent, cross-checked
+// cases from AWS's own "Signature Version 4 Test Suite" — see that
+// file's doc comment for exactly which ones, why those four, and the
+// citation for where they came from. Every one of those vectors was
+// ALSO independently recomputed with Python's stdlib `hashlib`/`hmac`
+// (not this Swift code) before being written into the test file, so
+// the fixtures are not merely "copied from a web page" — they are
+// numerically self-consistent (SHA-256 of the canonical request really
+// does equal the published hash; the chained-HMAC signing key really
+// does produce the published signature).
+//
+// Every intermediate step of the algorithm — canonical request, its
+// hash, the string-to-sign, the derived signing key, and the final
+// signature — is exposed as its own `public static` function so tests
+// (and callers debugging a signature mismatch against a real AWS
+// error response) can inspect each stage independently, not just the
+// final `Authorization` header.
+// ---------------------------------------------------------------------------
+
+// MARK: - AWSV4Signer
+
+public enum AWSV4Signer {
+
+    // MARK: - Credentials
+
+    /// The access key ID / secret access key (and optional STS session
+    /// token) used to sign a request.
+    ///
+    /// Never logged, never written to argv, never hardcoded — see
+    /// `S3Uploader.loadCredential(apiKeyManager:bucket:region:endpoint:)`
+    /// for the one production path that constructs this type, which
+    /// reads the secret exclusively from the system Keychain via
+    /// `APIKeyManager`.
+    public struct Credentials: Sendable {
+        public let accessKeyID: String
+        public let secretAccessKey: String
+
+        /// Optional STS session token for temporary credentials. When
+        /// present, the caller is responsible for ALSO adding an
+        /// `x-amz-security-token` header (with this same value) to the
+        /// `headers` dictionary passed to `sign(...)` and including it
+        /// in `signedHeaders` — this type does not do that
+        /// automatically, since which headers get signed is entirely
+        /// the caller's decision (`headers` is signed exactly as
+        /// given, nothing added or removed).
+        public let sessionToken: String?
+
+        public init(accessKeyID: String, secretAccessKey: String, sessionToken: String? = nil) {
+            self.accessKeyID = accessKeyID
+            self.secretAccessKey = secretAccessKey
+            self.sessionToken = sessionToken
+        }
+    }
+
+    // MARK: - SigningResult
+
+    /// Every step of the SigV4 algorithm for one request, in the order
+    /// AWS's documentation presents them. Exposed as a flat struct
+    /// (rather than only returning the final header) precisely so
+    /// tests can assert on each stage against AWS's own published
+    /// intermediate values, not just trust that a correct final
+    /// signature implies every step along the way was correct.
+    public struct SigningResult: Sendable {
+        /// Task 1 output: `HTTPMethod\nCanonicalURI\nCanonicalQueryString\n
+        /// CanonicalHeaders\n\nSignedHeaders\nHashedPayload`.
+        public let canonicalRequest: String
+
+        /// Hex SHA-256 of `canonicalRequest`.
+        public let hashedCanonicalRequest: String
+
+        /// `<dateStamp>/<region>/<service>/aws4_request`.
+        public let credentialScope: String
+
+        /// Task 2 output: `AWS4-HMAC-SHA256\n<amzDate>\n<credentialScope>\n
+        /// <hashedCanonicalRequest>`.
+        public let stringToSign: String
+
+        /// Task 3's derived signing key
+        /// (`HMAC(HMAC(HMAC(HMAC("AWS4"+secret, date), region), service),
+        /// "aws4_request")`), hex-encoded so tests can compare it
+        /// against AWS's published signing-key fixtures without
+        /// exposing raw key bytes through the normal call path.
+        public let signingKeyHex: String
+
+        /// Task 4 output: hex HMAC-SHA256 of `stringToSign` under the
+        /// derived signing key. This is the value AWS calls "the
+        /// signature".
+        public let signature: String
+
+        /// Semicolon-joined, lower-cased, sorted header names that were
+        /// included in the signature — must equal exactly the
+        /// `SignedHeaders=` value a verifier will check against.
+        public let signedHeaders: String
+
+        /// The complete `Authorization` header value:
+        /// `AWS4-HMAC-SHA256 Credential=<accessKeyID>/<credentialScope>,
+        /// SignedHeaders=<signedHeaders>, Signature=<signature>`.
+        public let authorizationHeader: String
+    }
+
+    /// Sentinel payload-hash value AWS accepts in place of a real
+    /// SHA-256 for S3 requests whose body is streamed rather than
+    /// buffered up front (e.g. a large file `PUT`). See
+    /// `S3Uploader.buildSignedUploadRequest` for why the file upload
+    /// path uses this instead of hashing the file.
+    public static let unsignedPayload = "UNSIGNED-PAYLOAD"
+
+    // MARK: - Public entry point
+
+    /// Computes the full SigV4 signature for one request.
+    ///
+    /// - Parameters:
+    ///   - method: HTTP method, e.g. `"GET"` or `"PUT"`, used verbatim
+    ///     (AWS's algorithm does not case-normalize it, and neither
+    ///     does this function — callers must already pass the
+    ///     uppercase form AWS expects).
+    ///   - path: The request's absolute path (e.g. `"/my-object.mp4"`),
+    ///     already logically un-escaped — this function performs its
+    ///     own SigV4 percent-encoding per path segment (see
+    ///     `canonicalURI(path:)`); do not pre-percent-encode it
+    ///     yourself, or it will be double-encoded.
+    ///   - queryItems: The request's query parameters, unencoded. Taken
+    ///     as an explicit `[URLQueryItem]` rather than parsed back out
+    ///     of a `URL` because `Foundation.URL`'s `.query` accessor has
+    ///     historically inconsistent percent-decoding behaviour across
+    ///     OS versions — passing the already-decoded name/value pairs
+    ///     directly removes that ambiguity from a security-sensitive
+    ///     code path.
+    ///   - headers: Every header to include in the signature. Header
+    ///     *names* are case-insensitive per RFC 7230 and are
+    ///     lower-cased/sorted by this function; header *values* are
+    ///     trimmed and have internal whitespace runs collapsed to a
+    ///     single space, per the SigV4 canonicalization rule. Must
+    ///     include at minimum a `Host` entry — this function does not
+    ///     inject one for you, so the exact header set that gets
+    ///     signed is the exact header set the caller must also
+    ///     actually send.
+    ///   - payloadHash: The hex SHA-256 of the request body (see
+    ///     `sha256Hex(data:)`), or `AWSV4Signer.unsignedPayload` for a
+    ///     streamed body AWS lets you skip hashing. Whatever value is
+    ///     passed here MUST equal the `x-amz-content-sha256` header
+    ///     value the caller actually sends — S3 rejects a mismatch.
+    ///   - date: The request timestamp. See this type's file-overview
+    ///     doc comment for why this is never defaulted to `Date()`
+    ///     internally.
+    ///   - region: AWS region, e.g. `"us-east-1"`.
+    ///   - service: AWS service signing name, e.g. `"s3"`.
+    ///   - credentials: The access key / secret key to sign with.
+    /// - Returns: Every intermediate value plus the final
+    ///   `Authorization` header.
+    public static func sign(
+        method: String,
+        path: String,
+        queryItems: [URLQueryItem] = [],
+        headers: [String: String],
+        payloadHash: String,
+        date: Date,
+        region: String,
+        service: String,
+        credentials: Credentials
+    ) -> SigningResult {
+        let stamp = dateStamp(from: date)
+        let amzDateString = amzDate(from: date)
+
+        let uri = canonicalURI(path: path)
+        let query = canonicalQueryString(queryItems: queryItems)
+        let (headersBlock, signed) = canonicalHeaders(headers)
+
+        let creq = canonicalRequest(
+            method: method,
+            canonicalURI: uri,
+            canonicalQueryString: query,
+            canonicalHeadersBlock: headersBlock,
+            signedHeaders: signed,
+            hashedPayload: payloadHash
+        )
+        let hashedCreq = sha256Hex(creq)
+
+        let scope = credentialScope(dateStamp: stamp, region: region, service: service)
+        let sts = stringToSign(amzDate: amzDateString, credentialScope: scope, hashedCanonicalRequest: hashedCreq)
+
+        let key = signingKey(secretAccessKey: credentials.secretAccessKey, dateStamp: stamp, region: region, service: service)
+        let signatureBytes = hmacSHA256(key: key, message: Data(sts.utf8))
+        let signatureHex = hex(signatureBytes)
+
+        let authHeader = authorizationHeader(
+            accessKeyID: credentials.accessKeyID,
+            credentialScope: scope,
+            signedHeaders: signed,
+            signature: signatureHex
+        )
+
+        return SigningResult(
+            canonicalRequest: creq,
+            hashedCanonicalRequest: hashedCreq,
+            credentialScope: scope,
+            stringToSign: sts,
+            signingKeyHex: hex(key),
+            signature: signatureHex,
+            signedHeaders: signed,
+            authorizationHeader: authHeader
+        )
+    }
+
+    // MARK: - Task 1: Canonical request
+
+    /// SigV4-encodes a URI path: every path SEGMENT is percent-encoded
+    /// per `uriEncode(_:)` (unreserved characters `A-Za-z0-9-_.~` pass
+    /// through, everything else becomes uppercase `%XX` of its UTF-8
+    /// bytes), but the `/` segment separators themselves are left
+    /// alone — encoding them would turn `/a/b` into `%2Fa%2Fb`, which
+    /// is not what the canonical-URI step means by "URI-encode".
+    ///
+    /// Deliberately does NOT normalize `.`/`..` path segments the way
+    /// generic HTTP clients do. AWS's canonicalization spec calls that
+    /// out as a service-specific exception for S3: object keys containing
+    /// literal `.`/`..` segments must be signed and sent exactly as
+    /// given, never collapsed — S3 treats them as opaque key
+    /// characters, not path-navigation tokens.
+    ///
+    /// - Parameter path: The absolute path, NOT pre-percent-encoded
+    ///   (e.g. `"/videos/a b.mp4"`, not `"/videos/a%20b.mp4"`).
+    /// - Returns: The canonical URI, e.g. `"/videos/a%20b.mp4"`.
+    public static func canonicalURI(path: String) -> String {
+        let effectivePath = path.isEmpty ? "/" : path
+        let segments = effectivePath.split(separator: "/", omittingEmptySubsequences: false)
+        return segments.map { uriEncode(String($0)) }.joined(separator: "/")
+    }
+
+    /// Builds the canonical query string: URI-encode every parameter
+    /// name and value, then sort the encoded pairs by name and (for
+    /// ties) by value, per AWS's canonicalization spec.
+    ///
+    /// - Parameter queryItems: The unencoded query parameters.
+    /// - Returns: `""` for no parameters, otherwise
+    ///   `"name1=value1&name2=value2"` in sorted order.
+    public static func canonicalQueryString(queryItems: [URLQueryItem]) -> String {
+        let encodedPairs = queryItems.map { item in
+            (name: uriEncode(item.name), value: uriEncode(item.value ?? ""))
+        }
+        let sortedPairs = encodedPairs.sorted { lhs, rhs in
+            lhs.name == rhs.name ? lhs.value < rhs.value : lhs.name < rhs.name
+        }
+        return sortedPairs.map { "\($0.name)=\($0.value)" }.joined(separator: "&")
+    }
+
+    /// Builds the canonical headers block and the `SignedHeaders` list.
+    ///
+    /// Header names are lower-cased; values are trimmed and have
+    /// internal whitespace runs collapsed to a single space (SigV4's
+    /// canonicalization rule, mirroring RFC 7230 §3.2.4 header-value
+    /// folding). Headers are sorted by (lower-cased) name. If the
+    /// caller's dictionary happens to contain two distinct keys that
+    /// differ only by case (e.g. both `"Host"` and `"host"` — unusual,
+    /// since `S3Uploader` always builds this dictionary with unique
+    /// canonical-cased keys), their values are combined with `,` in
+    /// whatever order `Dictionary` iterates them, matching AWS's
+    /// documented duplicate-header handling; do not rely on that
+    /// ordering being stable if you exercise this edge case directly.
+    ///
+    /// - Parameter headers: The headers to sign, keyed by header name.
+    /// - Returns: The canonical headers block (each line
+    ///   `"name:value\n"`, including the trailing newline AWS's spec
+    ///   requires after the last header) and the `;`-joined
+    ///   `SignedHeaders` value.
+    public static func canonicalHeaders(_ headers: [String: String]) -> (block: String, signedHeaders: String) {
+        var merged: [String: [String]] = [:]
+        for (key, value) in headers {
+            merged[key.lowercased(), default: []].append(collapseWhitespace(value))
+        }
+        let sortedKeys = merged.keys.sorted()
+        let block = sortedKeys.map { key -> String in
+            "\(key):\(merged[key]!.joined(separator: ","))\n"
+        }.joined()
+        let signedHeaders = sortedKeys.joined(separator: ";")
+        return (block, signedHeaders)
+    }
+
+    /// Assembles Task 1's canonical request:
+    /// `HTTPMethod\nCanonicalURI\nCanonicalQueryString\nCanonicalHeaders\n
+    /// \nSignedHeaders\nHashedPayload`.
+    ///
+    /// `canonicalHeadersBlock` already carries its own trailing
+    /// newline (see `canonicalHeaders(_:)`), so joining with `"\n"`
+    /// here naturally produces the blank line AWS's spec requires
+    /// between the headers block and `SignedHeaders`.
+    public static func canonicalRequest(
+        method: String,
+        canonicalURI: String,
+        canonicalQueryString: String,
+        canonicalHeadersBlock: String,
+        signedHeaders: String,
+        hashedPayload: String
+    ) -> String {
+        [
+            method,
+            canonicalURI,
+            canonicalQueryString,
+            canonicalHeadersBlock,
+            signedHeaders,
+            hashedPayload,
+        ].joined(separator: "\n")
+    }
+
+    // MARK: - Task 2: String to sign
+
+    /// `<dateStamp>/<region>/<service>/aws4_request`.
+    public static func credentialScope(dateStamp: String, region: String, service: String) -> String {
+        "\(dateStamp)/\(region)/\(service)/aws4_request"
+    }
+
+    /// Task 2's string to sign:
+    /// `AWS4-HMAC-SHA256\n<amzDate>\n<credentialScope>\n
+    /// <hex SHA-256 of the canonical request>`.
+    public static func stringToSign(
+        amzDate: String,
+        credentialScope: String,
+        hashedCanonicalRequest: String
+    ) -> String {
+        [
+            "AWS4-HMAC-SHA256",
+            amzDate,
+            credentialScope,
+            hashedCanonicalRequest,
+        ].joined(separator: "\n")
+    }
+
+    // MARK: - Task 3: Signing key
+
+    /// Derives the request-scoped signing key via the chained-HMAC
+    /// construction AWS's spec requires:
+    /// `HMAC(HMAC(HMAC(HMAC("AWS4"+secret, date), region), service),
+    /// "aws4_request")`. Each step re-uses the previous step's raw
+    /// digest bytes as the NEXT HMAC's key — none of the intermediate
+    /// values are hex-encoded along the way (only the final signature,
+    /// in `sign(...)`, is hex-encoded for transmission).
+    ///
+    /// - Parameters:
+    ///   - secretAccessKey: The raw AWS secret access key (never
+    ///     `"AWS4"`-prefixed by the caller — this function adds that
+    ///     prefix itself, per spec).
+    ///   - dateStamp: `yyyyMMdd`, e.g. `"20150830"` — see `dateStamp(from:)`.
+    ///   - region: AWS region, e.g. `"us-east-1"`.
+    ///   - service: AWS service signing name, e.g. `"s3"`.
+    /// - Returns: The raw 32-byte signing key.
+    public static func signingKey(
+        secretAccessKey: String,
+        dateStamp: String,
+        region: String,
+        service: String
+    ) -> Data {
+        let kSecret = Data("AWS4\(secretAccessKey)".utf8)
+        let kDate = hmacSHA256(key: kSecret, message: Data(dateStamp.utf8))
+        let kRegion = hmacSHA256(key: kDate, message: Data(region.utf8))
+        let kService = hmacSHA256(key: kRegion, message: Data(service.utf8))
+        let kSigning = hmacSHA256(key: kService, message: Data("aws4_request".utf8))
+        return kSigning
+    }
+
+    // MARK: - Task 4: Authorization header
+
+    /// `AWS4-HMAC-SHA256 Credential=<accessKeyID>/<credentialScope>,
+    /// SignedHeaders=<signedHeaders>, Signature=<signature>`.
+    public static func authorizationHeader(
+        accessKeyID: String,
+        credentialScope: String,
+        signedHeaders: String,
+        signature: String
+    ) -> String {
+        "AWS4-HMAC-SHA256 Credential=\(accessKeyID)/\(credentialScope), "
+            + "SignedHeaders=\(signedHeaders), Signature=\(signature)"
+    }
+
+    // MARK: - Date formatting
+
+    /// `yyyyMMdd'T'HHmmss'Z'` in UTC, e.g. `"20150830T123600Z"`.
+    ///
+    /// Built from a fresh, UTC-configured `Calendar` value on every
+    /// call — deliberately NOT a cached `DateFormatter`, which is a
+    /// mutable class Apple does not document as safe for concurrent
+    /// use from multiple threads. `Calendar`/`DateComponents` are
+    /// value types, so there is no shared mutable state here at all.
+    public static func amzDate(from date: Date) -> String {
+        let c = utcComponents(from: date, [.year, .month, .day, .hour, .minute, .second])
+        return String(format: "%04d%02d%02dT%02d%02d%02dZ", c.year!, c.month!, c.day!, c.hour!, c.minute!, c.second!)
+    }
+
+    /// `yyyyMMdd` in UTC, e.g. `"20150830"`.
+    public static func dateStamp(from date: Date) -> String {
+        let c = utcComponents(from: date, [.year, .month, .day])
+        return String(format: "%04d%02d%02d", c.year!, c.month!, c.day!)
+    }
+
+    private static func utcComponents(from date: Date, _ components: Set<Calendar.Component>) -> DateComponents {
+        var calendar = Calendar(identifier: .gregorian)
+        // Force-unwrap is safe: "UTC" is one of the fixed IANA zone
+        // identifiers `TimeZone(identifier:)` always resolves.
+        // swiftlint:disable:next force_unwrapping
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar.dateComponents(components, from: date)
+    }
+
+    // MARK: - Hashing (CommonCrypto)
+
+    /// Hex-encoded SHA-256 of a UTF-8 string — used internally for the
+    /// canonical-request hash and exposed publicly for callers who
+    /// need to hash a string payload themselves.
+    public static func sha256Hex(_ string: String) -> String {
+        hex(sha256(Data(string.utf8)))
+    }
+
+    /// Hex-encoded SHA-256 of raw bytes — for the `x-amz-content-sha256`
+    /// header when a request's body genuinely is hashed up front
+    /// (small in-memory bodies). `S3Uploader`'s file `PUT` does NOT use
+    /// this — see its doc comment for why it uses `unsignedPayload`
+    /// instead.
+    public static func sha256Hex(data: Data) -> String {
+        hex(sha256(data))
+    }
+
+    /// Hex-encoded HMAC-SHA256 — exposed publicly so tests can pin the
+    /// underlying CommonCrypto glue against a well-known vector (RFC
+    /// 4231 Test Case 1) independently of the full SigV4 algorithm, in
+    /// addition to the end-to-end AWS SigV4 vectors.
+    public static func hmacSHA256Hex(key: Data, message: Data) -> String {
+        hex(hmacSHA256(key: key, message: message))
+    }
+
+    private static func sha256(_ data: Data) -> Data {
+        #if canImport(CommonCrypto)
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes { buffer in
+            _ = CC_SHA256(buffer.baseAddress, CC_LONG(data.count), &digest)
+        }
+        return Data(digest)
+        #else
+        preconditionFailure("AWSV4Signer requires CommonCrypto, available only on Apple platforms.")
+        #endif
+    }
+
+    private static func hmacSHA256(key: Data, message: Data) -> Data {
+        #if canImport(CommonCrypto)
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        key.withUnsafeBytes { keyBuffer in
+            message.withUnsafeBytes { messageBuffer in
+                CCHmac(
+                    CCHmacAlgorithm(kCCHmacAlgSHA256),
+                    keyBuffer.baseAddress, key.count,
+                    messageBuffer.baseAddress, message.count,
+                    &digest
+                )
+            }
+        }
+        return Data(digest)
+        #else
+        preconditionFailure("AWSV4Signer requires CommonCrypto, available only on Apple platforms.")
+        #endif
+    }
+
+    private static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - URI encoding
+
+    /// RFC 3986 unreserved-character percent-encoding, as SigV4's spec
+    /// requires: `A-Z a-z 0-9 - _ . ~` pass through unchanged; every
+    /// other byte of the string's UTF-8 representation becomes an
+    /// uppercase `%XX`. Multi-byte (non-ASCII) characters are encoded
+    /// one UTF-8 byte at a time, each as its own `%XX` — e.g. `"ሴ"`
+    /// (U+1234) becomes `"%E1%88%B4"`, its three UTF-8 bytes.
+    private static func uriEncode(_ string: String) -> String {
+        var result = ""
+        result.reserveCapacity(string.utf8.count)
+        for byte in string.utf8 {
+            if isUnreservedByte(byte) {
+                result.unicodeScalars.append(Unicode.Scalar(byte))
+            } else {
+                result += String(format: "%%%02X", byte)
+            }
+        }
+        return result
+    }
+
+    private static func isUnreservedByte(_ byte: UInt8) -> Bool {
+        switch byte {
+        case UInt8(ascii: "A")...UInt8(ascii: "Z"),
+             UInt8(ascii: "a")...UInt8(ascii: "z"),
+             UInt8(ascii: "0")...UInt8(ascii: "9"),
+             UInt8(ascii: "-"), UInt8(ascii: "."), UInt8(ascii: "_"), UInt8(ascii: "~"):
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Trims leading/trailing whitespace and collapses any internal run
+    /// of spaces/tabs to a single space, per SigV4's header-value
+    /// canonicalization rule.
+    private static func collapseWhitespace(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        var result = ""
+        result.reserveCapacity(trimmed.count)
+        var lastWasSpace = false
+        for ch in trimmed {
+            if ch == " " || ch == "\t" {
+                if !lastWasSpace { result.append(" ") }
+                lastWasSpace = true
+            } else {
+                result.append(ch)
+                lastWasSpace = false
+            }
+        }
+        return result
+    }
+}

--- a/Sources/ConverterEngine/Cloud/S3Uploader.swift
+++ b/Sources/ConverterEngine/Cloud/S3Uploader.swift
@@ -6,17 +6,30 @@
 // ============================================================================
 
 import Foundation
-#if canImport(CommonCrypto)
-import CommonCrypto
-#endif
+// NOTE: AWS Signature V4 signing (the reason this file used to import
+// CommonCrypto directly) now lives in `AWSV4Signer.swift`, which does
+// the actual CommonCrypto-based hashing/HMAC work — see
+// `buildSignedUploadRequest` below, which calls into it. No direct
+// CommonCrypto usage remains in this file.
 
 // MARK: - S3Uploader
 
 /// Builds AWS S3 (and S3-compatible) upload requests.
 ///
-/// Supports multipart uploads, pre-signed URLs, and AWS Signature V4
-/// authentication. Also works with S3-compatible providers like
-/// Backblaze B2, DigitalOcean Spaces, MinIO, and Cloudflare R2.
+/// `buildSignedUploadRequest` produces a genuinely AWS Signature
+/// Version 4-signed `PUT` request (via `AWSV4Signer`, Issue #459 Bundle
+/// 1b) ready to hand to `CloudUploadExecutor` — or use the
+/// `CloudUploadExecutor.uploadToS3(fileURL:credential:objectKey:...)`
+/// convenience below to build-and-execute in one call. Also works with
+/// S3-compatible providers like Backblaze B2, DigitalOcean Spaces,
+/// MinIO, and Cloudflare R2 that support virtual-hosted-style
+/// requests, via `CloudCredential.endpoint`.
+///
+/// Multipart upload (required by S3 for objects over 5 GiB) is not yet
+/// wired end-to-end — `buildInitiateMultipartURL`/`buildUploadPartURL`/
+/// `calculatePartCount`/`shouldUseMultipart` below exist for that but
+/// nothing drives them through a full initiate → parts → complete flow
+/// yet. See `// TODO(#459)` on `buildSignedUploadRequest`.
 ///
 /// Phase 12.2
 public struct S3Uploader: Sendable {
@@ -36,10 +49,16 @@ public struct S3Uploader: Sendable {
         return "\(endpoint)/\(bucket)/\(objectKey)"
     }
 
-    /// Build HTTP headers for an S3 PUT request (simplified, no signing).
+    /// Build HTTP headers for an S3 PUT request — content headers only,
+    /// deliberately WITHOUT authentication.
     ///
-    /// For production use, AWS Signature V4 signing is required.
-    /// This builds the basic header structure.
+    /// This does not include `Authorization`, `x-amz-date`, or
+    /// `x-amz-content-sha256` — a real upload needs AWS Signature V4
+    /// signing, which `buildSignedUploadRequest` (below) now provides.
+    /// This function is kept for callers that only need the
+    /// content-description headers (e.g. to preview what will be sent,
+    /// or for a pre-signed-URL flow where signing happens out of band)
+    /// and for backward compatibility with existing callers/tests.
     ///
     /// - Parameters:
     ///   - contentType: MIME type of the file.
@@ -134,6 +153,268 @@ public struct S3Uploader: Sendable {
         }
 
         return errors
+    }
+}
+
+// MARK: - S3Uploader + AWS Signature V4
+
+extension S3Uploader {
+
+    /// Builds the virtual-hosted-style S3 host for a bucket:
+    /// `<bucket>.s3.<region>.amazonaws.com`, or `<bucket>.<endpointHost>`
+    /// when `credential.endpoint` points at an S3-compatible provider
+    /// (Backblaze B2, DigitalOcean Spaces, MinIO, Cloudflare R2, ...).
+    private static func signingHost(credential: CloudCredential, bucket: String) -> String {
+        if let endpoint = credential.endpoint,
+           let endpointURL = URL(string: endpoint),
+           let endpointHost = endpointURL.host {
+            return "\(bucket).\(endpointHost)"
+        }
+        let region = credential.region ?? "us-east-1"
+        return "\(bucket).s3.\(region).amazonaws.com"
+    }
+
+    /// Build a fully AWS Signature Version 4-signed `PUT` request to
+    /// upload an object to S3 (or an S3-compatible endpoint) at
+    /// `https://<bucket>.s3.<region>.amazonaws.com/<objectKey>`.
+    ///
+    /// Single-`PUT` only — this matches S3's own 5 GiB single-request
+    /// limit.
+    /// // TODO(#459): multipart upload for files > 5 GiB — initiate →
+    /// per-part signed PUTs → complete, using
+    /// `calculatePartCount`/`shouldUseMultipart` (above) to decide
+    /// when to switch over. `buildInitiateMultipartURL`/
+    /// `buildUploadPartURL` (above) already build the right URLs; they
+    /// just are not yet driven through a full signed multipart flow.
+    ///
+    /// Uses `AWSV4Signer.unsignedPayload` (`"UNSIGNED-PAYLOAD"`) for
+    /// `x-amz-content-sha256` rather than hashing the file up front:
+    /// AWS explicitly documents this token for exactly this case — a
+    /// streamed body whose bytes should not have to be read twice.
+    /// `CloudUploadExecutor.upload` streams the file straight from
+    /// disk via `URLSession.upload(for:fromFile:)`; hashing first
+    /// would mean reading every multi-gigabyte output file twice
+    /// (once to hash, once to stream) for no security benefit S3
+    /// itself asks for on this path.
+    ///
+    /// Only `Host`, `x-amz-date`, and `x-amz-content-sha256` are
+    /// included in `SignedHeaders` — not `Content-Type`/
+    /// `Content-Length`/`x-amz-meta-*`. Those headers are still sent,
+    /// just not signed: `Content-Length` in particular is the one
+    /// `URLSession` recomputes itself from the file's real on-disk
+    /// size when streaming via `upload(for:fromFile:)` rather than
+    /// necessarily honouring whatever numeric value this function
+    /// wrote into the request ahead of time, so signing it would risk
+    /// a spurious `SignatureDoesNotMatch` if the two ever disagreed by
+    /// even one byte. The three headers that ARE signed are exactly
+    /// the three this function fully controls end-to-end.
+    ///
+    /// The exact same path string is used both to build the request's
+    /// `URL` and (inside `AWSV4Signer.sign`) to compute the signature —
+    /// both derive it via `AWSV4Signer.canonicalURI(path:)`, so the
+    /// bytes actually sent on the wire and the bytes that were signed
+    /// can never diverge (a manual "percent-encode for the URL, then
+    /// separately percent-encode again for signing" implementation
+    /// would risk exactly that kind of double-encoding mismatch).
+    ///
+    /// - Parameters:
+    ///   - credential: AWS/S3 credential — `apiKey` is the access key
+    ///     ID, `secret` is the secret access key. See
+    ///     `loadCredential(apiKeyManager:bucket:region:endpoint:)` for
+    ///     the Keychain-backed path that supplies these in production;
+    ///     this function itself never reads a key from anywhere — it
+    ///     only signs with whatever `credential` already carries, and
+    ///     never logs either field.
+    ///   - objectKey: The S3 object key (remote path), e.g.
+    ///     `"videos/movie.mp4"`. Not pre-percent-encoded.
+    ///   - contentType: MIME type of the file being uploaded.
+    ///   - contentLength: File size in bytes, sent as `Content-Length`
+    ///     (see the "not signed" note above).
+    ///   - metadata: Custom metadata, sent as `x-amz-meta-*` headers
+    ///     (also not signed — see above).
+    ///   - date: Request timestamp. Defaults to `Date()` — this is the
+    ///     one call site allowed to do that; the underlying
+    ///     `AWSV4Signer.sign(...)` core never defaults it internally,
+    ///     which is what keeps `AWSV4SignerTests` deterministic.
+    /// - Returns: A fully signed `URLRequest`, ready for
+    ///   `CloudUploadExecutor.upload(fileURL:request:)` (or use
+    ///   `CloudUploadExecutor.uploadToS3` below to skip this call
+    ///   entirely). `nil` if the credential is missing the access key,
+    ///   secret key, or bucket, `objectKey` is empty, or a valid `URL`
+    ///   could not be constructed.
+    public static func buildSignedUploadRequest(
+        credential: CloudCredential,
+        objectKey: String,
+        contentType: String,
+        contentLength: Int64,
+        metadata: [String: String] = [:],
+        date: Date = Date()
+    ) -> URLRequest? {
+        guard let accessKeyID = credential.apiKey, !accessKeyID.isEmpty,
+              let secretAccessKey = credential.secret, !secretAccessKey.isEmpty,
+              let bucket = credential.bucket, !bucket.isEmpty,
+              !objectKey.isEmpty else {
+            return nil
+        }
+
+        let host = signingHost(credential: credential, bucket: bucket)
+        let rawPath = objectKey.hasPrefix("/") ? objectKey : "/\(objectKey)"
+        // The single source of truth for path percent-encoding: used
+        // here to build the actual `URL`, and again (recomputed
+        // identically, since it is a pure function of `rawPath`)
+        // inside `AWSV4Signer.sign` below to compute the signature.
+        let encodedPath = AWSV4Signer.canonicalURI(path: rawPath)
+        guard let url = URL(string: "https://\(host)\(encodedPath)") else { return nil }
+
+        let region = credential.region ?? "us-east-1"
+        let amzDate = AWSV4Signer.amzDate(from: date)
+        let payloadHash = AWSV4Signer.unsignedPayload
+
+        let signedHeaderSet: [String: String] = [
+            "host": host,
+            "x-amz-date": amzDate,
+            "x-amz-content-sha256": payloadHash,
+        ]
+
+        let result = AWSV4Signer.sign(
+            method: "PUT",
+            path: rawPath,
+            headers: signedHeaderSet,
+            payloadHash: payloadHash,
+            date: date,
+            region: region,
+            service: "s3",
+            credentials: AWSV4Signer.Credentials(accessKeyID: accessKeyID, secretAccessKey: secretAccessKey)
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        // `URLSession` derives the `Host` it actually sends from the
+        // request's `URL` (it is one of the headers Foundation
+        // restricts callers from overriding), which already equals
+        // `host` by construction above — this explicit `setValue` is
+        // belt-and-braces documentation of intent, not load-bearing.
+        request.setValue(host, forHTTPHeaderField: "Host")
+        request.setValue(amzDate, forHTTPHeaderField: "x-amz-date")
+        request.setValue(payloadHash, forHTTPHeaderField: "x-amz-content-sha256")
+        request.setValue(result.authorizationHeader, forHTTPHeaderField: "Authorization")
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        request.setValue("\(contentLength)", forHTTPHeaderField: "Content-Length")
+        for (key, value) in metadata {
+            request.setValue(value, forHTTPHeaderField: "x-amz-meta-\(key)")
+        }
+
+        return request
+    }
+
+    /// Loads AWS S3 access key ID + secret access key from the system
+    /// Keychain via `APIKeyManager` (provider `.awsS3`) and combines
+    /// them with the given bucket/region/endpoint into a
+    /// `CloudCredential` ready for `buildSignedUploadRequest`.
+    ///
+    /// Mirrors `CloudStorageProfileStore.loadProfiles(apiKeyManager:)`,
+    /// which does the equivalent job for the OAuth-token providers: the
+    /// access key ID and secret access key NEVER live in
+    /// `PostEncodeAction.config`, a plain settings file, argv, or a log
+    /// line — only in the system Keychain, reached exclusively through
+    /// `APIKeyManager` → `KeychainStore` (`SecItem*`; see
+    /// `APIKeyManager.swift`).
+    ///
+    /// - Parameters:
+    ///   - apiKeyManager: The manager to read the stored key from.
+    ///     Defaults to a fresh `APIKeyManager()` against the standard
+    ///     on-disk metadata location (only non-sensitive metadata lives
+    ///     there — the secrets themselves are Keychain-only; see
+    ///     `APIKeyManager`'s doc comment).
+    ///   - bucket: The target S3 bucket name.
+    ///   - region: AWS region. Defaults to `"us-east-1"` if omitted.
+    ///   - endpoint: Optional S3-compatible custom endpoint (Backblaze
+    ///     B2, DigitalOcean Spaces, MinIO, Cloudflare R2, ...).
+    /// - Returns: A populated `CloudCredential`, or `nil` if no AWS S3
+    ///   key is currently stored in the Keychain.
+    public static func loadCredential(
+        apiKeyManager: APIKeyManager = APIKeyManager(),
+        bucket: String,
+        region: String? = nil,
+        endpoint: String? = nil
+    ) -> CloudCredential? {
+        guard let stored = apiKeyManager.key(for: .awsS3),
+              !stored.apiKey.isEmpty,
+              let secretKey = stored.secretKey, !secretKey.isEmpty else {
+            return nil
+        }
+        return CloudCredential(
+            provider: .awsS3,
+            apiKey: stored.apiKey,
+            secret: secretKey,
+            endpoint: endpoint,
+            region: region,
+            bucket: bucket
+        )
+    }
+}
+
+// MARK: - CloudUploadExecutor + S3
+
+extension CloudUploadExecutor {
+
+    /// Uploads `fileURL` to S3 (or an S3-compatible endpoint) via a
+    /// single AWS Signature V4-signed `PUT`, executed for real through
+    /// `upload(fileURL:request:progress:)` — the same 2xx-only success
+    /// contract, retry/backoff, and byte-level progress every other
+    /// provider this type drives already gets (Issue #459 Bundle 1b —
+    /// S3 was the one provider still building a request nobody ever
+    /// sent; see `S3Uploader`'s previous doc comment, replaced by this
+    /// change, which said exactly that).
+    ///
+    /// - Parameters:
+    ///   - fileURL: The local file to upload.
+    ///   - credential: AWS/S3 credential (access key, secret, bucket,
+    ///     region, optional custom endpoint). See
+    ///     `S3Uploader.loadCredential` for the Keychain-backed path
+    ///     that supplies this without ever touching argv or a log.
+    ///   - objectKey: The S3 object key (remote path).
+    ///   - contentType: MIME type override. Defaults to
+    ///     `UploadConfig.contentType(for:)`, based on the file's
+    ///     extension, when omitted.
+    ///   - metadata: Custom `x-amz-meta-*` metadata.
+    ///   - progress: Optional byte-level progress callback — see
+    ///     `upload(fileURL:request:progress:parseSuccess:)`'s doc
+    ///     comment for its threading contract.
+    /// - Returns: The real `UploadResult`.
+    /// - Throws: `UploadError.transport` if the local file's size
+    ///   could not be read or the signed request could not be built
+    ///   (missing credential fields), or the real `UploadError` from
+    ///   the executed transfer otherwise.
+    public func uploadToS3(
+        fileURL: URL,
+        credential: CloudCredential,
+        objectKey: String,
+        contentType: String? = nil,
+        metadata: [String: String] = [:],
+        progress: (@Sendable (UploadProgress) -> Void)? = nil
+    ) async throws -> UploadResult {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+              let fileSize = attributes[.size] as? Int64 else {
+            throw UploadError.transport("Could not determine the size of \(fileURL.lastPathComponent).")
+        }
+
+        let resolvedContentType = contentType ?? UploadConfig.contentType(for: fileURL.lastPathComponent)
+
+        guard let request = S3Uploader.buildSignedUploadRequest(
+            credential: credential,
+            objectKey: objectKey,
+            contentType: resolvedContentType,
+            contentLength: fileSize,
+            metadata: metadata
+        ) else {
+            throw UploadError.transport(
+                "Could not build a signed S3 upload request — check that the access key, "
+                    + "secret key, bucket, and object key are all configured."
+            )
+        }
+
+        return try await upload(fileURL: fileURL, request: request, progress: progress)
     }
 }
 

--- a/Tests/ConverterEngineTests/AWSV4SignerTests.swift
+++ b/Tests/ConverterEngineTests/AWSV4SignerTests.swift
@@ -1,0 +1,578 @@
+// ============================================================================
+// MeedyaConverter — AWSV4SignerTests (Issue #459, Bundle 1b)
+// Copyright © 2026 MWBM Partners Ltd. All rights reserved.
+// Proprietary and confidential. Unauthorized copying or distribution
+// of this file, via any medium, is strictly prohibited.
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// MARK: - File Overview
+// ---------------------------------------------------------------------------
+// AWSV4Signer is security-sensitive cryptographic signing code. "Looks
+// right" is not a review standard for that — this file instead reproduces
+// AWS's own PUBLISHED test vectors byte-for-byte, so a correct
+// implementation is independently verifiable without a local build (this
+// repo builds macOS-only; this Swift file has never been compiled by the
+// author — CI's `Build & Test (macOS)` job is the actual compile+run gate).
+//
+// ### Vector source
+//
+// Four cases from the AWS "Signature Version 4 Test Suite" — the fixed
+// worked examples AWS itself published to let implementers validate a
+// SigV4 signer (access key `AKIDEXAMPLE`, secret
+// `wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY`, request date
+// `Fri, 30 Aug 2015 12:36:00 GMT` / `20150830T123600Z`, region
+// `us-east-1`, service `service`, host `example.amazonaws.com`):
+//
+//   - `get-vanilla` — the baseline case: canonical request, its SHA-256
+//     hash, string-to-sign, and final signature for a bare `GET /`.
+//   - `get-vanilla-query-order-key-case` — same request with two query
+//     parameters supplied out of order (`Param2` before `Param1`),
+//     verifying `canonicalQueryString(queryItems:)` sorts by name.
+//   - `get-unreserved` — a path built entirely from the RFC 3986
+//     "unreserved" character set (`-._~0-9A-Za-z`), verifying
+//     `canonicalURI(path:)` passes those through WITHOUT percent-encoding
+//     them (a common signer bug: over-encoding unreserved characters
+//     produces a signature AWS rejects).
+//   - `get-utf8` — a path containing a non-ASCII character (U+1234
+//     "ሴ"), verifying multi-byte UTF-8 percent-encoding is done one raw
+//     byte at a time (`"ሴ"` → `"%E1%88%B4"`), not one Unicode scalar at
+//     a time.
+//
+// This exact test suite (canonical request / string-to-sign / signing-key
+// / authorization-header fixtures per named case) is long-standing and
+// widely mirrored/re-used by independent SigV4 implementations across the
+// ecosystem (e.g. it is vendored into MongoDB's `libmongocrypt` under
+// `kms-message/aws-sig-v4-test-suite/`, and is the same suite referenced
+// by `aws/aws-sdk-js` issue #853 and multiple other SDKs' own test
+// suites) — it is the standard cross-implementation correctness
+// reference for SigV4, not a one-off blog post.
+//
+// ### Independent double-check
+//
+// Every one of the four fixtures below was ALSO independently
+// recomputed from first principles using Python's standard-library
+// `hashlib`/`hmac` (not Swift, not this signer, not a copy-paste of the
+// published page) before being written into this file — i.e. each
+// published (canonical-request-hash, string-to-sign, signature) triple
+// was confirmed to be internally self-consistent: hashing the exact
+// canonical-request text really does yield the published hash, and
+// chaining `HMAC-SHA256` through date→region→service→"aws4_request"
+// really does derive a key that reproduces the published signature.
+// That rules out a transcription error in the fixtures themselves,
+// independently of whether `AWSV4Signer`'s Swift implementation matches
+// them.
+//
+// Two additional low-level sanity checks pin the underlying CommonCrypto
+// glue in isolation, independent of the SigV4 algorithm on top of it:
+//   - `sha256Hex` against the well-known NIST SHA-256 vectors for `""`
+//     and `"abc"`.
+//   - `hmacSHA256Hex` against RFC 4231 Test Case 1.
+//
+// Per this repo's test policy (see the header comment in
+// `ConverterEngineTests.swift`), only the PUBLIC API is exercised —
+// `import ConverterEngine`, no `@testable import`.
+// ---------------------------------------------------------------------------
+
+import XCTest
+import ConverterEngine
+
+final class AWSV4SignerTests: XCTestCase {
+
+    // MARK: - Shared fixture constants (AWS Signature Version 4 Test Suite)
+
+    private let testAccessKeyID = "AKIDEXAMPLE"
+    private let testSecretAccessKey = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+    private let testRegion = "us-east-1"
+    private let testService = "service"
+    private let testHost = "example.amazonaws.com"
+
+    /// `2015-08-30T12:36:00Z`, i.e. `20150830T123600Z` / date stamp
+    /// `20150830` — the fixed timestamp every AWS Signature Version 4
+    /// Test Suite case uses. Constructed from a raw Unix timestamp
+    /// (independently computed with Python's `datetime`, NOT via
+    /// `AWSV4Signer.amzDate`/`dateStamp` — using the code under test to
+    /// build its own input would make the date-formatting assertions
+    /// below circular).
+    private let testDate = Date(timeIntervalSince1970: 1_440_938_160)
+
+    private var testCredentials: AWSV4Signer.Credentials {
+        AWSV4Signer.Credentials(accessKeyID: testAccessKeyID, secretAccessKey: testSecretAccessKey)
+    }
+
+    // MARK: - Date formatting (inputs to every vector below)
+
+    func test_amzDate_formatsFixedTimestampAsAWSExpects() {
+        XCTAssertEqual(AWSV4Signer.amzDate(from: testDate), "20150830T123600Z")
+    }
+
+    func test_dateStamp_formatsFixedTimestampAsAWSExpects() {
+        XCTAssertEqual(AWSV4Signer.dateStamp(from: testDate), "20150830")
+    }
+
+    // MARK: - Low-level crypto sanity (independent of the SigV4 algorithm)
+
+    /// NIST's published SHA-256 test vectors.
+    func test_sha256Hex_matchesKnownVectors() {
+        XCTAssertEqual(
+            AWSV4Signer.sha256Hex(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
+        XCTAssertEqual(
+            AWSV4Signer.sha256Hex("abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        )
+    }
+
+    /// RFC 4231 Test Case 1 (key = 20 bytes of `0x0b`, data = "Hi There").
+    /// Pins the `CCHmac` glue itself, independent of SigV4's own
+    /// chained-HMAC construction on top of it.
+    func test_hmacSHA256Hex_matchesRFC4231TestCase1() {
+        let key = Data(repeating: 0x0b, count: 20)
+        let data = Data("Hi There".utf8)
+        XCTAssertEqual(
+            AWSV4Signer.hmacSHA256Hex(key: key, message: data),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        )
+    }
+
+    // MARK: - AWS Signature Version 4 Test Suite: get-vanilla
+
+    /// The baseline vector: `GET /` with only `Host` and `X-Amz-Date`
+    /// signed, no query string, empty body.
+    ///
+    /// Source: AWS Signature Version 4 Test Suite, case `get-vanilla`.
+    /// Published fixtures for this case:
+    ///   - canonical request hash:
+    ///     `bb579772317eb040ac9ed261061d46c1f17a8133879d6129b6e1c25292927e63`
+    ///   - string to sign ends with the same hash, scope
+    ///     `20150830/us-east-1/service/aws4_request`
+    ///   - signature:
+    ///     `5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31`
+    ///   - Authorization header:
+    ///     `AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request,
+    ///     SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31`
+    func test_getVanilla_matchesAWSPublishedVectors() {
+        let expectedCanonicalRequest = [
+            "GET",
+            "/",
+            "",
+            "host:\(testHost)",
+            "x-amz-date:20150830T123600Z",
+            "",
+            "host;x-amz-date",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        ].joined(separator: "\n")
+
+        let expectedHash = "bb579772317eb040ac9ed261061d46c1f17a8133879d6129b6e1c25292927e63"
+        let expectedScope = "20150830/us-east-1/service/aws4_request"
+        let expectedStringToSign = [
+            "AWS4-HMAC-SHA256",
+            "20150830T123600Z",
+            expectedScope,
+            expectedHash,
+        ].joined(separator: "\n")
+        let expectedSignature = "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"
+        let expectedAuthHeader =
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, "
+            + "SignedHeaders=host;x-amz-date, Signature=5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"
+
+        let result = AWSV4Signer.sign(
+            method: "GET",
+            path: "/",
+            queryItems: [],
+            headers: ["host": testHost, "x-amz-date": "20150830T123600Z"],
+            payloadHash: AWSV4Signer.sha256Hex(""),
+            date: testDate,
+            region: testRegion,
+            service: testService,
+            credentials: testCredentials
+        )
+
+        // Every intermediate step, not just the final signature.
+        XCTAssertEqual(result.canonicalRequest, expectedCanonicalRequest, "canonical request text must match byte-for-byte")
+        XCTAssertEqual(result.hashedCanonicalRequest, expectedHash, "hash of the canonical request must match AWS's published value")
+        XCTAssertEqual(result.credentialScope, expectedScope)
+        XCTAssertEqual(result.stringToSign, expectedStringToSign)
+        XCTAssertEqual(result.signedHeaders, "host;x-amz-date")
+        XCTAssertEqual(result.signature, expectedSignature, "final signature hex must match AWS's published value exactly")
+        XCTAssertEqual(result.authorizationHeader, expectedAuthHeader)
+
+        // Cross-check: hashing the exact canonical-request STRING this
+        // implementation built (independent of whatever internal
+        // machinery produced it) reproduces the published hash — proves
+        // `canonicalRequest` and `hashedCanonicalRequest` are mutually
+        // consistent, not just each individually equal to the fixture.
+        XCTAssertEqual(AWSV4Signer.sha256Hex(result.canonicalRequest), expectedHash)
+    }
+
+    // MARK: - AWS Signature Version 4 Test Suite: get-vanilla-query-order-key-case
+
+    /// Query parameters supplied out of sorted order
+    /// (`?Param2=value2&Param1=value1`) must be canonicalized in sorted
+    /// order (`Param1=value1&Param2=value2`) before signing.
+    ///
+    /// Source: AWS Signature Version 4 Test Suite, case
+    /// `get-vanilla-query-order-key-case`. Published canonical-request
+    /// hash: `816cd5b414d056048ba4f7c5386d6e0533120fb1fcfa93762cf0fc39e2cf19e0`.
+    /// Published signature:
+    /// `b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500`.
+    func test_getVanillaQueryOrderKeyCase_sortsQueryParametersByName() {
+        let queryItems = [
+            URLQueryItem(name: "Param2", value: "value2"),
+            URLQueryItem(name: "Param1", value: "value1"),
+        ]
+        XCTAssertEqual(
+            AWSV4Signer.canonicalQueryString(queryItems: queryItems),
+            "Param1=value1&Param2=value2",
+            "query parameters must be sorted by name, not left in request order"
+        )
+
+        let result = AWSV4Signer.sign(
+            method: "GET",
+            path: "/",
+            queryItems: queryItems,
+            headers: ["host": testHost, "x-amz-date": "20150830T123600Z"],
+            payloadHash: AWSV4Signer.sha256Hex(""),
+            date: testDate,
+            region: testRegion,
+            service: testService,
+            credentials: testCredentials
+        )
+
+        XCTAssertEqual(
+            result.hashedCanonicalRequest,
+            "816cd5b414d056048ba4f7c5386d6e0533120fb1fcfa93762cf0fc39e2cf19e0"
+        )
+        XCTAssertEqual(
+            result.signature,
+            "b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500"
+        )
+    }
+
+    // MARK: - AWS Signature Version 4 Test Suite: get-unreserved
+
+    /// A path built entirely from RFC 3986 unreserved characters must
+    /// pass through `canonicalURI` completely unchanged — none of
+    /// `-._~0-9A-Za-z` may be percent-encoded.
+    ///
+    /// Source: AWS Signature Version 4 Test Suite, case
+    /// `get-unreserved`. Published signature:
+    /// `07ef7494c76fa4850883e2b006601f940f8a34d404d0cfa977f52a65bbf5f24f`.
+    func test_getUnreserved_passesUnreservedCharactersThroughUnencoded() {
+        let path = "/-._~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        XCTAssertEqual(
+            AWSV4Signer.canonicalURI(path: path), path,
+            "unreserved characters must never be percent-encoded"
+        )
+
+        let result = AWSV4Signer.sign(
+            method: "GET",
+            path: path,
+            queryItems: [],
+            headers: ["host": testHost, "x-amz-date": "20150830T123600Z"],
+            payloadHash: AWSV4Signer.sha256Hex(""),
+            date: testDate,
+            region: testRegion,
+            service: testService,
+            credentials: testCredentials
+        )
+
+        XCTAssertEqual(
+            result.signature,
+            "07ef7494c76fa4850883e2b006601f940f8a34d404d0cfa977f52a65bbf5f24f"
+        )
+    }
+
+    // MARK: - AWS Signature Version 4 Test Suite: get-utf8
+
+    /// A path containing a multi-byte UTF-8 character must be
+    /// percent-encoded one raw UTF-8 BYTE at a time:
+    /// `"ሴ"` (U+1234) is the three bytes `E1 88 B4`, so its canonical
+    /// URI is `"%E1%88%B4"`.
+    ///
+    /// Source: AWS Signature Version 4 Test Suite, case `get-utf8`.
+    /// Published signature:
+    /// `8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85`.
+    func test_getUtf8_percentEncodesMultiByteUTF8PathPerByte() {
+        XCTAssertEqual(AWSV4Signer.canonicalURI(path: "/ሴ"), "/%E1%88%B4")
+
+        let result = AWSV4Signer.sign(
+            method: "GET",
+            path: "/ሴ",
+            queryItems: [],
+            headers: ["host": testHost, "x-amz-date": "20150830T123600Z"],
+            payloadHash: AWSV4Signer.sha256Hex(""),
+            date: testDate,
+            region: testRegion,
+            service: testService,
+            credentials: testCredentials
+        )
+
+        XCTAssertEqual(
+            result.signature,
+            "8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85"
+        )
+    }
+
+    // MARK: - Determinism
+
+    /// Signing the same request with the same fixed `date` twice must
+    /// yield byte-identical output. `sign(...)` never calls `Date()`
+    /// itself (see `AWSV4Signer`'s file-overview doc comment) — this is
+    /// the regression test for that invariant staying true.
+    func test_sign_isDeterministicForAFixedDate() {
+        let make = {
+            AWSV4Signer.sign(
+                method: "GET",
+                path: "/",
+                queryItems: [],
+                headers: ["host": self.testHost, "x-amz-date": "20150830T123600Z"],
+                payloadHash: AWSV4Signer.sha256Hex(""),
+                date: self.testDate,
+                region: self.testRegion,
+                service: self.testService,
+                credentials: self.testCredentials
+            )
+        }
+        let first = make()
+        let second = make()
+        XCTAssertEqual(first.signature, second.signature)
+        XCTAssertEqual(first.canonicalRequest, second.canonicalRequest)
+        XCTAssertEqual(first.authorizationHeader, second.authorizationHeader)
+    }
+
+    // MARK: - Header canonicalization details
+
+    func test_canonicalHeaders_lowercasesSortsAndCollapsesWhitespace() {
+        let (block, signed) = AWSV4Signer.canonicalHeaders([
+            "X-Amz-Date": "20150830T123600Z",
+            "Host": "example.amazonaws.com",
+            "X-Custom":  "  a   b  ", // leading/trailing + collapsed internal whitespace
+        ])
+        XCTAssertEqual(signed, "host;x-amz-date;x-custom", "signed headers must be lower-cased and sorted")
+        XCTAssertTrue(block.contains("host:example.amazonaws.com\n"))
+        XCTAssertTrue(block.contains("x-amz-date:20150830T123600Z\n"))
+        XCTAssertTrue(block.contains("x-custom:a b\n"), "internal whitespace runs must collapse to a single space, and leading/trailing whitespace must be trimmed")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MARK: - S3Uploader signing integration
+// ---------------------------------------------------------------------------
+//
+// These tests exercise `S3Uploader.buildSignedUploadRequest` — the
+// production call site that hands `AWSV4Signer` a real bucket/key/host —
+// structurally: the request's method, host, headers, and
+// `Authorization` SHAPE. They deliberately do not assert a specific
+// signature hex the way the `AWSV4SignerTests` vectors above do (there
+// is no AWS-published fixture for an arbitrary bucket/region/date
+// combination); the signature's numeric correctness is already pinned
+// by the four vector tests above, since `buildSignedUploadRequest`
+// calls the exact same `AWSV4Signer.sign(...)` entry point.
+// ---------------------------------------------------------------------------
+
+final class S3UploaderSigningTests: XCTestCase {
+
+    private let fixedDate = Date(timeIntervalSince1970: 1_440_938_160) // 2015-08-30T12:36:00Z
+
+    private func sampleCredential(endpoint: String? = nil) -> CloudCredential {
+        CloudCredential(
+            provider: .awsS3,
+            apiKey: "AKIDEXAMPLE",
+            secret: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            endpoint: endpoint,
+            region: "eu-west-1",
+            bucket: "my-bucket"
+        )
+    }
+
+    func test_buildSignedUploadRequest_hostMethodAndHeaders() throws {
+        let request = try XCTUnwrap(
+            S3Uploader.buildSignedUploadRequest(
+                credential: sampleCredential(),
+                objectKey: "videos/output.mp4",
+                contentType: "video/mp4",
+                contentLength: 12_345,
+                metadata: ["title": "Test Video"],
+                date: fixedDate
+            )
+        )
+
+        XCTAssertEqual(request.httpMethod, "PUT")
+        XCTAssertEqual(request.url?.host, "my-bucket.s3.eu-west-1.amazonaws.com")
+        XCTAssertEqual(request.url?.path, "/videos/output.mp4")
+        XCTAssertEqual(request.url?.scheme, "https")
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-amz-date"), "20150830T123600Z")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-amz-content-sha256"), "UNSIGNED-PAYLOAD")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "video/mp4")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Length"), "12345")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-amz-meta-title"), "Test Video")
+
+        let authHeader = try XCTUnwrap(request.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertTrue(authHeader.hasPrefix("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/eu-west-1/s3/aws4_request, "))
+        XCTAssertTrue(authHeader.contains("SignedHeaders=host;x-amz-content-sha256;x-amz-date"))
+
+        // The signature is a 64-character lowercase hex string (32-byte
+        // HMAC-SHA256 digest) — its exact value is already pinned by
+        // `AWSV4SignerTests`, since this call path uses the same
+        // `AWSV4Signer.sign(...)` those vectors verify.
+        let signaturePrefix = "Signature="
+        guard let range = authHeader.range(of: signaturePrefix) else {
+            return XCTFail("Authorization header missing Signature=")
+        }
+        let signature = String(authHeader[range.upperBound...])
+        XCTAssertEqual(signature.count, 64)
+        XCTAssertTrue(signature.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    }
+
+    func test_buildSignedUploadRequest_isDeterministicForAFixedDate() throws {
+        let first = try XCTUnwrap(
+            S3Uploader.buildSignedUploadRequest(
+                credential: sampleCredential(),
+                objectKey: "videos/output.mp4",
+                contentType: "video/mp4",
+                contentLength: 12_345,
+                date: fixedDate
+            )
+        )
+        let second = try XCTUnwrap(
+            S3Uploader.buildSignedUploadRequest(
+                credential: sampleCredential(),
+                objectKey: "videos/output.mp4",
+                contentType: "video/mp4",
+                contentLength: 12_345,
+                date: fixedDate
+            )
+        )
+        XCTAssertEqual(
+            first.value(forHTTPHeaderField: "Authorization"),
+            second.value(forHTTPHeaderField: "Authorization")
+        )
+    }
+
+    func test_buildSignedUploadRequest_customEndpoint_usesVirtualHostedStyleOnThatHost() throws {
+        let request = try XCTUnwrap(
+            S3Uploader.buildSignedUploadRequest(
+                credential: sampleCredential(endpoint: "https://s3.us-west-002.backblazeb2.com"),
+                objectKey: "output.mkv",
+                contentType: "video/x-matroska",
+                contentLength: 999,
+                date: fixedDate
+            )
+        )
+        XCTAssertEqual(request.url?.host, "my-bucket.s3.us-west-002.backblazeb2.com")
+    }
+
+    func test_buildSignedUploadRequest_encodesSpacesAndSpecialCharactersInObjectKey() throws {
+        let request = try XCTUnwrap(
+            S3Uploader.buildSignedUploadRequest(
+                credential: sampleCredential(),
+                objectKey: "my videos/a movie (2026).mp4",
+                contentType: "video/mp4",
+                contentLength: 1,
+                date: fixedDate
+            )
+        )
+        // `/` stays a path separator; the space and parentheses within
+        // each segment are percent-encoded in the literal request URL.
+        let absoluteString = try XCTUnwrap(request.url?.absoluteString)
+        XCTAssertTrue(
+            absoluteString.contains("/my%20videos/a%20movie%20%282026%29.mp4"),
+            "expected percent-encoded object key path in \(absoluteString)"
+        )
+        // `Foundation.URL.path` decodes percent-escapes back out; sanity
+        // check it round-trips to the original (unencoded) object key.
+        XCTAssertEqual(request.url?.path, "/my videos/a movie (2026).mp4")
+    }
+
+    func test_buildSignedUploadRequest_returnsNilForIncompleteCredential() {
+        let missingSecret = CloudCredential(provider: .awsS3, apiKey: "AKID", bucket: "bucket")
+        XCTAssertNil(
+            S3Uploader.buildSignedUploadRequest(
+                credential: missingSecret,
+                objectKey: "key.mp4",
+                contentType: "video/mp4",
+                contentLength: 1,
+                date: fixedDate
+            )
+        )
+
+        let missingBucket = CloudCredential(provider: .awsS3, apiKey: "AKID", secret: "secret")
+        XCTAssertNil(
+            S3Uploader.buildSignedUploadRequest(
+                credential: missingBucket,
+                objectKey: "key.mp4",
+                contentType: "video/mp4",
+                contentLength: 1,
+                date: fixedDate
+            )
+        )
+
+        let emptyObjectKey = CloudCredential(provider: .awsS3, apiKey: "AKID", secret: "secret", bucket: "bucket")
+        XCTAssertNil(
+            S3Uploader.buildSignedUploadRequest(
+                credential: emptyObjectKey,
+                objectKey: "",
+                contentType: "video/mp4",
+                contentLength: 1,
+                date: fixedDate
+            )
+        )
+    }
+
+    // MARK: - loadCredential (Keychain wiring)
+
+    /// An empty `APIKeyManager` (no key ever stored) must yield `nil` —
+    /// never a credential with empty/placeholder secrets. This does not
+    /// touch the Keychain at all (`APIKeyManager.key(for:)` on an
+    /// unpopulated in-memory store returns `nil` before any Keychain
+    /// read), so it is safe to run on any CI runner without the
+    /// Keychain-availability skip-probe
+    /// `APIKeyManagerKeychainTests.probeKeychainPersistence()` uses for
+    /// its Keychain-*write* tests.
+    func test_loadCredential_returnsNilWhenNoKeyIsStored() {
+        let isolatedManager = APIKeyManager(
+            storageDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("s3uploader-tests-empty-\(UUID().uuidString)"),
+            keychainService: "Ltd.MWBMpartners.MeedyaConverter.Tests.S3.\(UUID().uuidString)"
+        )
+        XCTAssertNil(
+            S3Uploader.loadCredential(apiKeyManager: isolatedManager, bucket: "my-bucket")
+        )
+    }
+
+    /// `storeKey` updates `APIKeyManager`'s in-memory `keys` array
+    /// immediately (Keychain persistence is a best-effort side effect
+    /// attempted afterwards — see `APIKeyManager.storeKey`'s
+    /// implementation), so reading it back via the SAME manager
+    /// instance (no reopen) exercises `loadCredential`'s field mapping
+    /// deterministically without depending on Keychain write success on
+    /// this host. Full Keychain round-trip persistence for `.awsS3`
+    /// secrets specifically is already covered by
+    /// `APIKeyManagerKeychainTests.test_apiKeyManager_roundTripsAllSecretsThroughKeychain`.
+    func test_loadCredential_mapsStoredAWSKeyIntoCloudCredential() {
+        let manager = APIKeyManager(
+            storageDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("s3uploader-tests-\(UUID().uuidString)"),
+            keychainService: "Ltd.MWBMpartners.MeedyaConverter.Tests.S3.\(UUID().uuidString)"
+        )
+        manager.storeKey(StoredAPIKey(
+            provider: .awsS3,
+            apiKey: "AKIA-FROM-KEYCHAIN",
+            secretKey: "secret-from-keychain"
+        ))
+
+        let credential = S3Uploader.loadCredential(
+            apiKeyManager: manager,
+            bucket: "my-bucket",
+            region: "eu-west-1"
+        )
+
+        XCTAssertEqual(credential?.apiKey, "AKIA-FROM-KEYCHAIN")
+        XCTAssertEqual(credential?.secret, "secret-from-keychain")
+        XCTAssertEqual(credential?.bucket, "my-bucket")
+        XCTAssertEqual(credential?.region, "eu-west-1")
+    }
+}


### PR DESCRIPTION
## Summary

Bundle 1b (#459) — a correct **AWS SigV4** signer + wired real S3 uploads. `S3Uploader` previously documented "simplified, no signing"; now it produces a properly-signed request and uploads real bytes via `CloudUploadExecutor` (from #460).

## Changes Made

- [x] **`AWSV4Signer.swift`** (new) — pure, stateless `enum`; `Date` injected (deterministic); each SigV4 step is its own function (canonical request → string-to-sign → chained-HMAC signing key → `Authorization`); HMAC-SHA256 via CommonCrypto
- [x] **`S3Uploader`** — `buildSignedUploadRequest` (`PUT https://<bucket>.s3.<region>.amazonaws.com/<key>`, `x-amz-content-sha256: UNSIGNED-PAYLOAD`) + `CloudUploadExecutor.uploadToS3`; credentials from Keychain (`APIKeyManager`), **never hardcoded / argv / logged**. Multipart >5 GiB marked `// TODO(#459)`
- [x] **`AWSV4SignerTests.swift`** — AWS's official **Signature V4 Test Suite** vectors (get-vanilla, query-order-key-case, unreserved, utf8) with exact expected signatures, each independently recomputed in Python; plus RFC 4231 HMAC + NIST SHA-256 vectors pinning the CommonCrypto glue

## Testing Done

CI is the gate (macOS-only) incl. **security checks**. This is cryptographic signing — the **AWS test vectors ARE the review** (exact-match assertions). Watch: first `CommonCrypto` `CC_SHA256`/`CCHmac` usage in this repo (existing crypto uses CryptoKit); `URL.path` percent-decoding (behind a robust `absoluteString` check).

## Related Issues

Addresses #459 (S3 upload now real; YouTube/Vimeo remain — OAuth-blocked). Annotates closed-in-error #162.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NF44GLcMisedfvxHzhscJQ)_