### PR TITLE
test(metadata): guard ID-tag passthrough + track SUITE_CORE bindings …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,32 @@
 
 ### Added
 
+- **Metadata / ID-tag passthrough guards + SUITE_CORE bindings tracking
+  (#478)** -- the cross-repo media-ID program's correctness obligation for
+  MeedyaConverter is that a conversion must NOT strip a file's external /
+  catalogue identifier tags (ISRC, UPC/ICPN, MusicBrainz IDs, ISWC, …).
+  Added argv-level guards in `ConverterEngineTests+FFmpegArguments.swift`
+  pinning the load-bearing property: a **default** encode emits
+  `-map_metadata 0` (copies the entire global metadata dictionary — every
+  tag family, not drop-unknown) and `-map_chapters 0`, and must not emit
+  `-map_metadata -1`; `copySourceMetadata = false` omits the copy-all
+  (negative control); and the `--no-copy-metadata` opt-out's trailing
+  `-map_metadata -1` is proven to come *after* the copy-all so ffmpeg's
+  last-arg-wins precedence genuinely strips. Added value-exact assertions
+  for `MetadataPassthroughBuilder` (`copyAll` == `-map_metadata 0`,
+  `strip` == `-map_metadata -1`) that close the positional wrong-but-green
+  gap in the pre-existing `contains(...)`-only tests. **Deliverable 1
+  (SUITE_CORE bindings) is tracking-only**: a note on `SuiteCoreMetadataAdapter`
+  records that the shared identifier vocabulary (MeedyaSuite-core's
+  `identifier_types` registry + `CommonTag`, MeedyaSuite-core#65) will reach
+  this app through that adapter once the core Swift bindings ship
+  (MeedyaSuite-core#28) — and that NO MeedyaConverter-local identifier model
+  should be added meanwhile (it would be throwaway). No dep bump; no new
+  identifier modelling. NOTE: this container has no Swift toolchain, so the
+  new tests were authored by source-review against the existing test idioms
+  and **compilation + `swift test` must be validated by CI** — not run
+  locally.
+
 - **`RenderFarmConfigurationLoader` consumes `RenderFarmSettingsTab`'s
   AppStorage settings (#346)** -- a new pure, Foundation-only
   `ConverterEngine.RenderFarmConfigurationLoader` reads the

--- a/Sources/ConverterEngine/SuiteCore/SuiteCoreMetadataAdapter.swift
+++ b/Sources/ConverterEngine/SuiteCore/SuiteCoreMetadataAdapter.swift
@@ -12,6 +12,19 @@
 //
 // GitHub Issue #371 — Integrate MeedyaSuite-core metadata providers via
 // Swift bindings.
+//
+// #478 (cross-repo media-ID program) — TRACKING NOTE, no code yet:
+// the shared external/catalogue identifier vocabulary (MeedyaSuite-core's
+// `identifier_types` registry + the `#[non_exhaustive] CommonTag` — see
+// MeedyaSuite-core#65) is intended to reach MeedyaConverter through THIS
+// adapter once the core Swift bindings land (scaffold: MeedyaSuite-core#28),
+// exposed under the existing `SUITE_CORE=1` build path. Until those bindings
+// ship, do NOT add a MeedyaConverter-local identifier model / enum — that
+// would be throwaway work the bindings replace. MeedyaConverter needs no new
+// identifier modelling in the meantime; its correctness obligation for the
+// program is tag *passthrough* (that a conversion preserves the ID tag
+// families), covered by the #478 argv guards in
+// ConverterEngineTests+FFmpegArguments.swift.
 // ============================================================================
 
 import Foundation

--- a/Tests/ConverterEngineTests/ConverterEngineTests+FFmpegArguments.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests+FFmpegArguments.swift
@@ -1062,4 +1062,103 @@ extension ConverterEngineTests {
         XCTAssertEqual(HDRTransferFunction.hlg.rawValue, "hlg")
     }
 
+    // -----------------------------------------------------------------
+    // MARK: - Metadata / ID-tag passthrough (#478)
+    // -----------------------------------------------------------------
+    //
+    // ELI5: converting a file must not throw away its ID stickers (ISRC, UPC,
+    // MusicBrainz IDs, ISWC …). These tests check the ffmpeg command we build
+    // says "copy every tag" by default, and only strips when the user asks.
+    //
+    // Why: #478 (the cross-repo media-ID program) makes tag preservation the
+    // load-bearing correctness property for MeedyaConverter — a converted file
+    // must keep the identifiers a downstream MeedyaManager/iHymns lookup relies
+    // on. At the argv level the guarantee is that a DEFAULT encode emits
+    // `-map_metadata 0`, which copies the ENTIRE global metadata dictionary
+    // (every tag family, including unknown/ID tags) from input 0 — i.e.
+    // copy-all, not drop-unknown (see `FFmpegArgumentBuilder.build()` ~line 385
+    // and `MetadataPassthroughMode.copyAll`). `--no-copy-metadata` appends a
+    // trailing `-map_metadata -1`; ffmpeg honours the LAST occurrence, so the
+    // opt-out still strips while the default stays copy-all.
+    //
+    // A byte-level round-trip (tag a real file → encode → re-probe) needs
+    // ffmpeg + tagged fixtures and is intentionally left to integration/CI;
+    // `build()` is pure and needs no ffmpeg, so these argv guards run in unit
+    // CI and are the mechanism that locks the property.
+
+    /// #478 helper — the first index `i` where `args[i] == a && args[i+1] == b`
+    /// (i.e. an ffmpeg flag/value pair appears consecutively), else `nil`.
+    private func indexOfArgPair(_ args: [String], _ a: String, _ b: String) -> Int? {
+        guard args.count >= 2 else { return nil }
+        for i in 0...(args.count - 2) where args[i] == a && args[i + 1] == b {
+            return i
+        }
+        return nil
+    }
+
+    /// #478: the default encode copies ALL source metadata (`-map_metadata 0`)
+    /// and chapters (`-map_chapters 0`), so ISRC / UPC / MusicBrainz / ISWC and
+    /// every other identifier tag survive a plain convert — and it must NOT
+    /// strip. This is the core correctness property of #478.
+    func test_argumentBuilder_metadata_copyAllByDefault_preservesIdTags() {
+        var builder = FFmpegArgumentBuilder()
+        builder.inputURL = URL(fileURLWithPath: "/tmp/in.mkv")
+        builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
+        // `copySourceMetadata` defaults to true — deliberately NOT set here, so
+        // this pins the DEFAULT behaviour.
+
+        let args = builder.build()
+        XCTAssertNotNil(
+            indexOfArgPair(args, "-map_metadata", "0"),
+            "Default encode must copy all source metadata (-map_metadata 0) so "
+            + "external/catalogue ID tags (ISRC/UPC/MB/ISWC) are preserved (#478)")
+        XCTAssertNotNil(
+            indexOfArgPair(args, "-map_chapters", "0"),
+            "Default encode must copy chapters (-map_chapters 0) (#478)")
+        XCTAssertNil(
+            indexOfArgPair(args, "-map_metadata", "-1"),
+            "Default encode must NOT strip metadata (#478)")
+    }
+
+    /// #478: opting out (`copySourceMetadata = false`) drops the copy-all
+    /// mapping — the negative control proving the default above is load-bearing
+    /// rather than unconditionally present.
+    func test_argumentBuilder_metadata_disabledOmitsCopyAll() {
+        var builder = FFmpegArgumentBuilder()
+        builder.inputURL = URL(fileURLWithPath: "/tmp/in.mkv")
+        builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
+        builder.copySourceMetadata = false
+
+        let args = builder.build()
+        XCTAssertNil(
+            indexOfArgPair(args, "-map_metadata", "0"),
+            "With copySourceMetadata=false the builder must not emit "
+            + "-map_metadata 0 (#478)")
+    }
+
+    /// #478: the CLI `--no-copy-metadata` path appends `-map_metadata -1` to
+    /// `extraArguments`, which `build()` emits AFTER the default
+    /// `-map_metadata 0`. ffmpeg honours the LAST occurrence, so the opt-out
+    /// genuinely strips — and, conversely, when the flag is absent the copy-all
+    /// default stands (see the copy-all test above).
+    func test_argumentBuilder_metadata_noCopyFlagStripsViaLastWins() {
+        var builder = FFmpegArgumentBuilder()
+        builder.inputURL = URL(fileURLWithPath: "/tmp/in.mkv")
+        builder.outputURL = URL(fileURLWithPath: "/tmp/out.mkv")
+        // Mirror EncodeCommand's --no-copy-metadata wiring.
+        builder.extraArguments = ["-map_metadata", "-1"]
+
+        let args = builder.build()
+        let copyIdx = indexOfArgPair(args, "-map_metadata", "0")
+        let stripIdx = indexOfArgPair(args, "-map_metadata", "-1")
+        XCTAssertNotNil(copyIdx, "default copy-all still emitted (#478)")
+        XCTAssertNotNil(stripIdx, "--no-copy-metadata must add -map_metadata -1 (#478)")
+        if let copyIdx, let stripIdx {
+            XCTAssertLessThan(
+                copyIdx, stripIdx,
+                "The strip (-map_metadata -1) must come AFTER the copy-all "
+                + "(-map_metadata 0) so ffmpeg's last-wins precedence strips (#478)")
+        }
+    }
+
 }

--- a/Tests/ConverterEngineTests/ConverterEngineTests+MetadataProviders.swift
+++ b/Tests/ConverterEngineTests/ConverterEngineTests+MetadataProviders.swift
@@ -332,6 +332,34 @@ extension ConverterEngineTests {
         XCTAssertTrue(args.contains("-1"))
     }
 
+    /// #478: value-exact guard for the copy-all mode. The two tests above use
+    /// `contains(...)`, which is positional-blind — a copyAll that regressed to
+    /// `["-map_metadata", "-1", …, "0"]` (i.e. actually stripping) would still
+    /// satisfy `contains("-map_metadata")` && `contains("0")`. Asserting the
+    /// EXACT array (`-map_metadata 0`, value "0" immediately after the flag)
+    /// kills that wrong-but-green case. `-map_metadata 0` is the mode that
+    /// preserves every external/catalogue ID tag family (ISRC/UPC/MB/ISWC).
+    func test_metadataPassthroughBuilder_copyAll_isExactlyMapMetadataZero() {
+        let args = MetadataPassthroughBuilder.buildMetadataArguments(
+            config: MetadataPassthroughConfig(mode: .copyAll)
+        )
+        XCTAssertEqual(
+            args, ["-map_metadata", "0"],
+            "copyAll must be exactly -map_metadata 0 (copies all tag families, #478)")
+    }
+
+    /// #478: value-exact guard for the strip mode — must be exactly
+    /// `-map_metadata -1`, so a strip cannot silently regress to `0` (copy-all)
+    /// and stay green.
+    func test_metadataPassthroughBuilder_strip_isExactlyMapMetadataMinusOne() {
+        let args = MetadataPassthroughBuilder.buildMetadataArguments(
+            config: MetadataPassthroughConfig(mode: .strip)
+        )
+        XCTAssertEqual(
+            args, ["-map_metadata", "-1"],
+            "strip must be exactly -map_metadata -1 (#478)")
+    }
+
     /// Verifies custom metadata strip arguments.
     func test_metadataPassthroughBuilder_custom() {
         let config = MetadataPassthroughConfig(


### PR DESCRIPTION
…(#478)

Part of the cross-repo media-ID program. MeedyaConverter needs no new identifier modelling; its correctness obligation is that a conversion must NOT strip a file's external/catalogue ID tags (ISRC, UPC/ICPN, MusicBrainz IDs, ISWC, …).

Deliverable 2 — metadata-passthrough guards (argv-level, CI-runnable):
- ConverterEngineTests+FFmpegArguments.swift: pin the load-bearing property that a DEFAULT encode emits `-map_metadata 0` (copies the ENTIRE global metadata dictionary from input 0 — every tag family, incl. the ID tags a downstream MeedyaManager/iHymns lookup depends on — i.e. copy-all, not drop-unknown) and `-map_chapters 0`, and must NOT emit `-map_metadata -1`; a negative control (`copySourceMetadata = false` omits the copy-all); and the `--no-copy-metadata` opt-out's trailing `-map_metadata -1` is proven to come AFTER the copy-all so ffmpeg's last-arg-wins precedence genuinely strips.
- ConverterEngineTests+MetadataProviders.swift: value-EXACT assertions for MetadataPassthroughBuilder (copyAll == ["-map_metadata","0"], strip == ["-map_metadata","-1"]), closing the positional wrong-but-green gap in the pre-existing `contains(...)`-only tests (which would pass a copyAll that actually stripped).
- `build()` is pure (constructs the argv, runs no ffmpeg), so these run in unit CI with no ffmpeg. A byte-level round-trip (tag a real file, encode, re-probe) needs ffmpeg + tagged fixtures and is left to integration/CI — noted in-code and filed as a follow-up.

Deliverable 1 — SUITE_CORE bindings adoption: TRACKING ONLY. A note on SuiteCoreMetadataAdapter records that the shared identifier vocabulary (MeedyaSuite-core's identifier_types registry + CommonTag, MeedyaSuite-core#65) will reach this app through that adapter once the core Swift bindings ship (MeedyaSuite-core#28), under the existing SUITE_CORE=1 path — and that NO MeedyaConverter-local identifier model should be added meanwhile (throwaway). No dep change, no new modelling.

CAVEAT: this environment has no Swift toolchain, so the new tests were authored by source-review against the existing test idioms; `swift build` / `swift test --parallel` were NOT run locally and must be validated by CI.


Claude-Session: https://claude.ai/code/session_01DNiDThGGEJujdRL9fNR2Bq

## Summary

Briefly describe the purpose and scope of this pull request.

## Changes Made

- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Testing Done

Describe the testing performed to validate these changes.

- [ ] Unit tests added or updated
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Tested on macOS
- [ ] Tested on iOS (if applicable)

## Related Issues

Link any related issues using keywords (e.g., `Closes #123`, `Fixes #456`, `Relates to #789`).

-

## Merge gate (standing tasks #1 / #1a / #6 / #12)

Confirm before merging — this is the gate, not an after-the-fact audit (see [.claude/standing_tasks.md](../.claude/standing_tasks.md)):

- [ ] **Milestone assigned** on every issue this PR closes
- [ ] **Acceptance-criteria boxes ticked** on each closed issue (or annotated as deferred with a tracking issue ref)
- [ ] **CHANGELOG.md** updated (entry under `[Unreleased]`)
- [ ] **`scripts/clean-dev-caches.sh --quick`** run after merge (standing task #12)

## Screenshots

If this PR includes UI changes, add before/after screenshots or recordings below.

| Before | After |
| ------ | ----- |
|        |       |
